### PR TITLE
Add comprehensive wasm-gc instruction coverage

### DIFF
--- a/docs/selfhost.md
+++ b/docs/selfhost.md
@@ -1,0 +1,291 @@
+# wasm-gc Self-Hosting
+
+This document summarizes the changes required to enable wasm5 (compiled with wasm-gc target) to parse, compile, and execute its own binary.
+
+## Overview
+
+wasm5 is a WebAssembly interpreter that can be built for two targets:
+
+- **wasm (linear memory)**: Traditional WebAssembly. ~490KB
+- **wasm-gc**: Uses GC proposal. ~310KB
+
+For the wasm-gc build to interpret itself, proper handling of wasm-gc specific type system (struct/array type subtyping) was required.
+
+## wasm-gc Instruction Coverage
+
+### Struct Operations (Complete)
+
+| Instruction | Description |
+|-------------|-------------|
+| `struct.new` | Create struct with field values |
+| `struct.new_default` | Create struct with default values |
+| `struct.get` | Get field value |
+| `struct.get_s` | Get packed field (sign-extend) |
+| `struct.get_u` | Get packed field (zero-extend) |
+| `struct.set` | Set field value |
+
+### Array Operations (Complete)
+
+| Instruction | Description |
+|-------------|-------------|
+| `array.new` | Create array with value and length |
+| `array.new_default` | Create array with default values |
+| `array.new_fixed` | Create array from stack values |
+| `array.new_data` | Create array from data segment |
+| `array.new_elem` | Create array from element segment |
+| `array.get` | Get element |
+| `array.get_s` | Get packed element (sign-extend) |
+| `array.get_u` | Get packed element (zero-extend) |
+| `array.set` | Set element |
+| `array.len` | Get array length |
+| `array.fill` | Fill array range |
+| `array.copy` | Copy between arrays |
+| `array.init_data` | Initialize from data segment |
+| `array.init_elem` | Initialize from element segment |
+
+### i31 Operations (Complete)
+
+| Instruction | Description |
+|-------------|-------------|
+| `ref.i31` | Create i31ref from i32 |
+| `i31.get_s` | Extract signed i32 |
+| `i31.get_u` | Extract unsigned i32 |
+
+### Reference Operations (Complete)
+
+| Instruction | Description |
+|-------------|-------------|
+| `ref.null` | Create null reference |
+| `ref.is_null` | Test if null |
+| `ref.eq` | Compare references |
+| `ref.as_non_null` | Assert non-null |
+| `ref.test` | Runtime type test |
+| `ref.cast` | Runtime type cast |
+
+### Branch Operations (Complete)
+
+| Instruction | Description |
+|-------------|-------------|
+| `br_on_null` | Branch if null |
+| `br_on_non_null` | Branch if non-null |
+| `br_on_cast` | Branch on successful cast |
+| `br_on_cast_fail` | Branch on failed cast |
+
+### Conversion Operations (Complete)
+
+| Instruction | Description |
+|-------------|-------------|
+| `any.convert_extern` | externref to anyref |
+| `extern.convert_any` | anyref to externref |
+
+## Required Changes for Self-Hosting
+
+### 1. Pattern Match Order Fix for TypeIndex Subtyping
+
+In `src/validate/validate_helpers.mbt`, the `is_subtype` function needed the `Ref(TypeIndex(...), ...)` pattern to match before more general patterns.
+
+```moonbit
+// Before: General pattern matches first, preventing TypeIndex handling
+(Ref(ht1, false), Ref(ht2, true)) => ht1 == ht2
+(Ref(TypeIndex(n1), nullable1), Ref(TypeIndex(n2), nullable2)) => ...
+
+// After: TypeIndex pattern placed first
+(Ref(TypeIndex(n1), nullable1), Ref(TypeIndex(n2), nullable2)) => ...
+(Ref(ht1, false), Ref(ht2, true)) => ht1 == ht2
+```
+
+### 2. Explicit Supertype Declaration Search
+
+The `is_type_index_subtype` function searches `module_.type_groups` to find explicit supertype declarations:
+
+```moonbit
+fn is_type_index_subtype(
+  module_ : @core.Module,
+  type_idx1 : Int,
+  type_idx2 : Int,
+) -> Bool {
+  if type_idx1 == type_idx2 {
+    return true
+  }
+
+  // Search type_groups for explicit supertype declarations
+  for group in module_.type_groups {
+    for subtype_def in group.subtypes {
+      if subtype_def.type_idx == type_idx1 {
+        for supertype in subtype_def.supertypes {
+          if supertype == type_idx2 ||
+             is_type_index_subtype(module_, supertype, type_idx2) {
+            return true
+          }
+        }
+      }
+    }
+  }
+
+  // Also check structural subtyping
+  ...
+}
+```
+
+### 3. Structural Subtyping Implementation
+
+In wasm-gc, structurally compatible types can be treated as subtypes even without explicit supertype declarations. The following functions were added:
+
+#### Struct Type Subtyping
+
+```moonbit
+fn is_struct_subtype(
+  module_ : @core.Module,
+  struct1 : @core.StructType,
+  struct2 : @core.StructType,
+) -> Bool {
+  // struct2's fields must be a prefix of struct1's fields
+  if struct2.fields.length() > struct1.fields.length() {
+    return false
+  }
+
+  for i in 0..<struct2.fields.length() {
+    let f1 = struct1.fields[i]
+    let f2 = struct2.fields[i]
+
+    // Mutability must match exactly
+    if f1.mutable != f2.mutable {
+      return false
+    }
+
+    // Check field type subtyping
+    if not(is_storage_type_subtype(module_, f1.storage, f2.storage, f1.mutable)) {
+      return false
+    }
+  }
+  true
+}
+```
+
+#### Array Type Subtyping
+
+```moonbit
+fn is_array_subtype(
+  module_ : @core.Module,
+  arr1 : @core.ArrayType,
+  arr2 : @core.ArrayType,
+) -> Bool {
+  if arr1.element.mutable != arr2.element.mutable {
+    return false
+  }
+  is_storage_type_subtype(module_, arr1.element.storage, arr2.element.storage, arr1.element.mutable)
+}
+```
+
+#### Function Type Subtyping
+
+```moonbit
+fn is_func_type_subtype(
+  module_ : @core.Module,
+  func1 : @core.FuncType,
+  func2 : @core.FuncType,
+) -> Bool {
+  // Parameters are contravariant
+  for i in 0..<func1.params.length() {
+    if not(is_subtype(module_, func2.params[i], func1.params[i])) {
+      return false
+    }
+  }
+  // Results are covariant
+  for i in 0..<func1.results.length() {
+    if not(is_subtype(module_, func1.results[i], func2.results[i])) {
+      return false
+    }
+  }
+  true
+}
+```
+
+### 4. NullRef as Subtype of TypeIndex References
+
+`NullRef` is recognized as a subtype of nullable struct/array typed references:
+
+```moonbit
+(NullRef, Ref(TypeIndex(n), true)) =>
+  is_struct_type_index(module_, n) || is_array_type_index(module_, n)
+```
+
+### 5. Runtime Type Checking for ref.test/ref.cast
+
+Runtime type checking was implemented to support `ref.test`, `ref.cast`, `br_on_cast`, and `br_on_cast_fail`:
+
+```moonbit
+fn gc_ref_matches_type(
+  rt : Runtime,
+  ref_value : UInt64,
+  target_type : Int,
+  target_nullable : Bool,
+) -> Bool {
+  // Check for null reference
+  if ref_value == 0UL {
+    return target_nullable
+  }
+
+  // Check for i31ref (encoded with lowest bit set)
+  if ref_value.land(1UL) == 1UL {
+    return target_type == -4 || target_type == -3 || target_type == -2
+  }
+
+  // Get GC object and check type compatibility
+  match gc_get_object(rt, ref_value.to_int()) {
+    Some(Struct(s)) =>
+      if target_type >= 0 {
+        gc_is_type_subtype(rt, s.type_idx, target_type)
+      } else {
+        target_type == -5 || target_type == -3 || target_type == -2
+      }
+    Some(Array(a)) =>
+      if target_type >= 0 {
+        gc_is_type_subtype(rt, a.type_idx, target_type)
+      } else {
+        target_type == -6 || target_type == -3 || target_type == -2
+      }
+    _ => false
+  }
+}
+```
+
+## Testing
+
+### Cross-Target Test
+
+wasm-gc build interprets linear wasm:
+
+```bash
+node --stack-size=8192 test/selfhost/test_wasm_gc_cross.mjs
+```
+
+### Recursive Self-Hosting Test
+
+wasm-gc build interprets itself:
+
+```bash
+node --stack-size=8192 test/selfhost/test_wasm_gc_recursive.mjs
+```
+
+## Related Files
+
+- `src/validate/validate_helpers.mbt` - Validation-time subtype checking
+- `src/runtime/ops_gc.mbt` - GC instruction runtime implementation
+- `src/runtime/compile_emit.mbt` - GC instruction compilation
+- `test/selfhost/` - Self-hosting test scripts
+
+## Type Encoding
+
+Abstract heap types are encoded as negative numbers for runtime type checking:
+
+| Code | Type |
+|------|------|
+| -2 | any |
+| -3 | eq |
+| -4 | i31 |
+| -5 | struct |
+| -6 | array |
+| -7 | func |
+| -8 | extern |
+| >= 0 | TypeIndex |

--- a/src/parse/parse_main.mbt
+++ b/src/parse/parse_main.mbt
@@ -137,3 +137,146 @@ pub fn parse(b : Bytes) -> @core.Module raise {
   @validate.validate_module(module_)
   module_
 }
+
+///|
+/// Parse a WebAssembly binary without validation (for debugging)
+pub fn parse_novalidate(b : Bytes) -> @core.Module raise {
+  parse_skip_validation(b)
+}
+
+///|
+/// Internal parse function that skips validation
+fn parse_skip_validation(b : Bytes) -> @core.Module raise {
+  let parser = Parser::new(b)
+
+  // Parse magic number
+  let magic = parser.read_bytes(4)
+  if magic[0].to_int() != 0x00 ||
+    magic[1].to_int() != 0x61 ||
+    magic[2].to_int() != 0x73 ||
+    magic[3].to_int() != 0x6D {
+    raise ParseError::InvalidMagic
+  }
+
+  // Parse version
+  let version = parser.read_bytes(4)
+  if version[0].to_int() != 0x01 ||
+    version[1].to_int() != 0x00 ||
+    version[2].to_int() != 0x00 ||
+    version[3].to_int() != 0x00 {
+    raise ParseError::UnsupportedVersion
+  }
+
+  // Parse sections
+  let mut types : Array[@core.TypeDef] = []
+  let mut type_groups : Array[@core.TypeGroup] = []
+  let customs : Array[@core.CustomSection] = []
+  let mut funcs : Array[UInt] = []
+  let mut tables : Array[@core.TableType] = []
+  let mut mems : Array[@core.MemType] = []
+  let mut globals : Array[@core.Global] = []
+  let mut tags : Array[@core.Tag] = []
+  let mut elems : Array[@core.Elem] = []
+  let mut datas : Array[@core.Data] = []
+  let mut start : UInt? = None
+  let mut imports : Array[@core.Import] = []
+  let mut exports : Array[@core.Export] = []
+  let mut codes : Array[@core.Code] = []
+  let mut last_section : @core.SectionId? = None
+  while not(parser.eof()) {
+    let section_id = parser.read_byte()
+    let section_size = parser.read_u32_leb128()
+    let section_start = parser.pos
+    match section_id {
+      0 => {
+        let name = parser.read_name()
+        let consumed = parser.pos - section_start
+        let remaining = section_size.reinterpret_as_int() - consumed
+        guard remaining >= 0 else {
+          raise ParseError::InvalidFormat("invalid custom section size")
+        }
+        let data = parser.read_bytes(remaining.reinterpret_as_uint()).to_bytes()
+        let placement = match last_section {
+          Some(kind) => @core.CustomPlacement::After(kind)
+          None => @core.CustomPlacement::Start
+        }
+        customs.push(@core.CustomSection::{ name, data, placement })
+        parser.pos = section_start + section_size.reinterpret_as_int()
+      }
+      1 => {
+        let (parsed_types, parsed_groups) = parse_type_section(parser)
+        types = parsed_types
+        type_groups = parsed_groups
+        last_section = Some(@core.SectionId::Type)
+      }
+      2 => {
+        imports = parse_import_section(parser)
+        last_section = Some(@core.SectionId::Import)
+      }
+      3 => {
+        funcs = parse_function_section(parser)
+        last_section = Some(@core.SectionId::Func)
+      }
+      4 => {
+        tables = parse_table_section(parser)
+        last_section = Some(@core.SectionId::Table)
+      }
+      5 => {
+        mems = parse_memory_section(parser)
+        last_section = Some(@core.SectionId::Memory)
+      }
+      6 => {
+        globals = parse_global_section(parser)
+        last_section = Some(@core.SectionId::Global)
+      }
+      13 => {
+        tags = parse_tag_section(parser)
+        last_section = Some(@core.SectionId::Tag)
+      }
+      7 => {
+        exports = parse_export_section(parser)
+        last_section = Some(@core.SectionId::Export)
+      }
+      8 => {
+        start = Some(parser.read_u32_leb128())
+        last_section = Some(@core.SectionId::Start)
+      }
+      9 => {
+        elems = parse_element_section(parser)
+        last_section = Some(@core.SectionId::Elem)
+      }
+      12 => {
+        let _ = parser.read_u32_leb128()
+        last_section = Some(@core.SectionId::DataCount)
+        parser.pos = section_start + section_size.reinterpret_as_int()
+      }
+      10 => {
+        codes = parse_code_section(parser)
+        last_section = Some(@core.SectionId::Code)
+      }
+      11 => {
+        datas = parse_data_section(parser)
+        last_section = Some(@core.SectionId::Data)
+      }
+      _ =>
+        // Unknown section - skip it
+        parser.pos = section_start + section_size.reinterpret_as_int()
+    }
+  }
+  @core.Module::{
+    types,
+    type_groups,
+    customs,
+    funcs,
+    tables,
+    mems,
+    globals,
+    tags,
+    elems,
+    datas,
+    start,
+    imports,
+    exports,
+    codes,
+  }
+}

--- a/src/runtime/compile_emit.mbt
+++ b/src/runtime/compile_emit.mbt
@@ -1214,10 +1214,28 @@ fn Compiler::compile_wasm_instr(
       }
       self.emit_fn(op_ref_as_non_null)
     }
-    RefTest(_ref_type, _nullable) => {
+    RefTest(ref_type, nullable) => {
       ctx.pop_type()
       ctx.push_type(I32)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_ref_test)
+      // Emit target type code (negative for abstract types, positive for TypeIndex)
+      let target_type = match ref_type {
+        Func => -7
+        Extern => -8
+        Any => -2
+        Eq => -3
+        I31 => -4
+        Struct => -5
+        Array => -6
+        Exn => -9
+        None => -10
+        NoFunc => -11
+        NoExtern => -12
+        NoExn => -13
+        TypeIndex(idx) => idx
+      }
+      self.emit_idx(target_type)
+      self.emit_idx(if nullable { 1 } else { 0 })
     }
     RefCast(ref_type, nullable) => {
       let target = reftype_to_valtype(ref_type)
@@ -1228,7 +1246,25 @@ fn Compiler::compile_wasm_instr(
       }
       ctx.pop_type()
       ctx.push_type(result_type)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_ref_cast)
+      // Emit target type code
+      let target_type = match ref_type {
+        Func => -7
+        Extern => -8
+        Any => -2
+        Eq => -3
+        I31 => -4
+        Struct => -5
+        Array => -6
+        Exn => -9
+        None => -10
+        NoFunc => -11
+        NoExtern => -12
+        NoExn => -13
+        TypeIndex(idx) => idx
+      }
+      self.emit_idx(target_type)
+      self.emit_idx(if nullable { 1 } else { 0 })
     }
     StructNew(type_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
@@ -1237,19 +1273,25 @@ fn Compiler::compile_wasm_instr(
         type_idx_int,
         "struct.new",
       )
-      ctx.pop_types(struct_type.fields.length())
+      let num_fields = struct_type.fields.length()
+      ctx.pop_types(num_fields)
       ctx.push_type(Ref(TypeIndex(type_idx_int), false))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_struct_new)
+      self.emit_idx(type_idx_int)
+      self.emit_idx(num_fields)
     }
     StructNewDefault(type_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
-      let _ = require_struct_type(
+      let struct_type = require_struct_type(
         self.module_,
         type_idx_int,
         "struct.new_default",
       )
+      let num_fields = struct_type.fields.length()
       ctx.push_type(Ref(TypeIndex(type_idx_int), false))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_struct_new_default)
+      self.emit_idx(type_idx_int)
+      self.emit_idx(num_fields)
     }
     StructGet(type_idx, field_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
@@ -1265,7 +1307,8 @@ fn Compiler::compile_wasm_instr(
       let field = struct_type.fields[field_idx_int]
       ctx.pop_type()
       ctx.push_type(storage_value_type(field.storage))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_struct_get)
+      self.emit_idx(field_idx_int)
     }
     StructGetS(type_idx, field_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
@@ -1278,9 +1321,17 @@ fn Compiler::compile_wasm_instr(
       if field_idx_int < 0 || field_idx_int >= struct_type.fields.length() {
         raise RuntimeError::InvalidType("struct.get_s: invalid field index")
       }
+      let field = struct_type.fields[field_idx_int]
+      let storage_type_code = match field.storage {
+        I8 => 0
+        I16 => 1
+        _ => 0
+      }
       ctx.pop_type()
       ctx.push_type(I32)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_struct_get_s)
+      self.emit_idx(field_idx_int)
+      self.emit_idx(storage_type_code)
     }
     StructGetU(type_idx, field_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
@@ -1293,9 +1344,17 @@ fn Compiler::compile_wasm_instr(
       if field_idx_int < 0 || field_idx_int >= struct_type.fields.length() {
         raise RuntimeError::InvalidType("struct.get_u: invalid field index")
       }
+      let field = struct_type.fields[field_idx_int]
+      let storage_type_code = match field.storage {
+        I8 => 0
+        I16 => 1
+        _ => 0
+      }
       ctx.pop_type()
       ctx.push_type(I32)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_struct_get_u)
+      self.emit_idx(field_idx_int)
+      self.emit_idx(storage_type_code)
     }
     StructSet(type_idx, field_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
@@ -1309,14 +1368,16 @@ fn Compiler::compile_wasm_instr(
         raise RuntimeError::InvalidType("struct.set: invalid field index")
       }
       ctx.pop_types(2)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_struct_set)
+      self.emit_idx(field_idx_int)
     }
     ArrayNew(type_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
       let _ = require_array_type(self.module_, type_idx_int, "array.new")
       ctx.pop_types(2)
       ctx.push_type(Ref(TypeIndex(type_idx_int), false))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_new)
+      self.emit_idx(type_idx_int)
     }
     ArrayNewDefault(type_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
@@ -1327,28 +1388,44 @@ fn Compiler::compile_wasm_instr(
       )
       ctx.pop_type()
       ctx.push_type(Ref(TypeIndex(type_idx_int), false))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_new_default)
+      self.emit_idx(type_idx_int)
     }
     ArrayNewFixed(type_idx, len) => {
       let type_idx_int = type_idx.reinterpret_as_int()
+      let len_int = len.reinterpret_as_int()
       let _ = require_array_type(self.module_, type_idx_int, "array.new_fixed")
-      ctx.pop_types(len.reinterpret_as_int())
+      ctx.pop_types(len_int)
       ctx.push_type(Ref(TypeIndex(type_idx_int), false))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_new_fixed)
+      self.emit_idx(type_idx_int)
+      self.emit_idx(len_int)
     }
-    ArrayNewData(type_idx, _data_idx) => {
+    ArrayNewData(type_idx, data_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
-      let _ = require_array_type(self.module_, type_idx_int, "array.new_data")
+      let data_idx_int = data_idx.reinterpret_as_int()
+      let array_type = require_array_type(
+        self.module_,
+        type_idx_int,
+        "array.new_data",
+      )
+      let elem_size = storage_byte_size(array_type.element.storage)
       ctx.pop_types(2)
       ctx.push_type(Ref(TypeIndex(type_idx_int), false))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_new_data)
+      self.emit_idx(type_idx_int)
+      self.emit_idx(data_idx_int)
+      self.emit_idx(elem_size)
     }
-    ArrayNewElem(type_idx, _elem_idx) => {
+    ArrayNewElem(type_idx, elem_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
+      let elem_idx_int = elem_idx.reinterpret_as_int()
       let _ = require_array_type(self.module_, type_idx_int, "array.new_elem")
       ctx.pop_types(2)
       ctx.push_type(Ref(TypeIndex(type_idx_int), false))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_new_elem)
+      self.emit_idx(type_idx_int)
+      self.emit_idx(elem_idx_int)
     }
     ArrayGet(type_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
@@ -1359,38 +1436,60 @@ fn Compiler::compile_wasm_instr(
       )
       ctx.pop_types(2)
       ctx.push_type(storage_value_type(array_type.element.storage))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_get)
     }
     ArrayGetS(type_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
-      let _ = require_array_type(self.module_, type_idx_int, "array.get_s")
+      let array_type = require_array_type(
+        self.module_,
+        type_idx_int,
+        "array.get_s",
+      )
+      let storage_type_code = match array_type.element.storage {
+        I8 => 0
+        I16 => 1
+        _ => 0
+      }
       ctx.pop_types(2)
       ctx.push_type(I32)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_get_s)
+      self.emit_idx(storage_type_code)
     }
     ArrayGetU(type_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
-      let _ = require_array_type(self.module_, type_idx_int, "array.get_u")
+      let array_type = require_array_type(
+        self.module_,
+        type_idx_int,
+        "array.get_u",
+      )
+      let storage_type_code = match array_type.element.storage {
+        I8 => 0
+        I16 => 1
+        _ => 0
+      }
       ctx.pop_types(2)
       ctx.push_type(I32)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_get_u)
+      self.emit_idx(storage_type_code)
     }
     ArraySet(type_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
       let _ = require_array_type(self.module_, type_idx_int, "array.set")
       ctx.pop_types(3)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_set)
+      ignore(type_idx_int)
     }
     ArrayLen => {
       ctx.pop_type()
       ctx.push_type(I32)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_len)
     }
     ArrayFill(type_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
       let _ = require_array_type(self.module_, type_idx_int, "array.fill")
       ctx.pop_types(4)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_fill)
+      ignore(type_idx_int)
     }
     ArrayCopy(dst_type, src_type) => {
       let dst_int = dst_type.reinterpret_as_int()
@@ -1398,54 +1497,126 @@ fn Compiler::compile_wasm_instr(
       let _ = require_array_type(self.module_, dst_int, "array.copy")
       let _ = require_array_type(self.module_, src_int, "array.copy")
       ctx.pop_types(5)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_copy)
     }
-    ArrayInitData(type_idx, _data_idx) => {
+    ArrayInitData(type_idx, data_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
-      let _ = require_array_type(self.module_, type_idx_int, "array.init_data")
+      let data_idx_int = data_idx.reinterpret_as_int()
+      let array_type = require_array_type(
+        self.module_,
+        type_idx_int,
+        "array.init_data",
+      )
+      let elem_size = storage_byte_size(array_type.element.storage)
       ctx.pop_types(4)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_init_data)
+      self.emit_idx(type_idx_int)
+      self.emit_idx(data_idx_int)
+      self.emit_idx(elem_size)
     }
-    ArrayInitElem(type_idx, _elem_idx) => {
+    ArrayInitElem(type_idx, elem_idx) => {
       let type_idx_int = type_idx.reinterpret_as_int()
+      let elem_idx_int = elem_idx.reinterpret_as_int()
       let _ = require_array_type(self.module_, type_idx_int, "array.init_elem")
       ctx.pop_types(4)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_array_init_elem)
+      self.emit_idx(type_idx_int)
+      self.emit_idx(elem_idx_int)
     }
-    BrOnCast(_label, _tref, _tnull, _sref, _snull) => {
+    BrOnCast(label, target_ref, target_nullable, _sref, _snull) => {
+      let label_int = label.reinterpret_as_int()
+      let arity = ctx.get_branch_arity(label_int)
+      let drop_count = ctx.calc_drop_count(label_int, arity)
       ctx.pop_type()
       ctx.push_type(Ref(Any, true))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_br_on_cast)
+      let target_pc_slot = self.ops.length()
+      if ctx.is_loop_target(label_int) {
+        self.emit_idx(ctx.get_target_pc(label_int))
+      } else {
+        self.emit_idx(0) // Placeholder
+        ctx.add_br_patch(label_int, target_pc_slot)
+      }
+      self.emit_idx(arity)
+      self.emit_idx(drop_count)
+      // Emit target type code
+      let target_type = match target_ref {
+        Func => -7
+        Extern => -8
+        Any => -2
+        Eq => -3
+        I31 => -4
+        Struct => -5
+        Array => -6
+        Exn => -9
+        None => -10
+        NoFunc => -11
+        NoExtern => -12
+        NoExn => -13
+        TypeIndex(idx) => idx
+      }
+      self.emit_idx(target_type)
+      self.emit_idx(if target_nullable { 1 } else { 0 })
     }
-    BrOnCastFail(_label, _tref, _tnull, _sref, _snull) => {
+    BrOnCastFail(label, target_ref, target_nullable, _sref, _snull) => {
+      let label_int = label.reinterpret_as_int()
+      let arity = ctx.get_branch_arity(label_int)
+      let drop_count = ctx.calc_drop_count(label_int, arity)
       ctx.pop_type()
       ctx.push_type(Ref(Any, true))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_br_on_cast_fail)
+      let target_pc_slot = self.ops.length()
+      if ctx.is_loop_target(label_int) {
+        self.emit_idx(ctx.get_target_pc(label_int))
+      } else {
+        self.emit_idx(0) // Placeholder
+        ctx.add_br_patch(label_int, target_pc_slot)
+      }
+      self.emit_idx(arity)
+      self.emit_idx(drop_count)
+      // Emit target type code
+      let target_type = match target_ref {
+        Func => -7
+        Extern => -8
+        Any => -2
+        Eq => -3
+        I31 => -4
+        Struct => -5
+        Array => -6
+        Exn => -9
+        None => -10
+        NoFunc => -11
+        NoExtern => -12
+        NoExn => -13
+        TypeIndex(idx) => idx
+      }
+      self.emit_idx(target_type)
+      self.emit_idx(if target_nullable { 1 } else { 0 })
     }
     AnyConvertExtern => {
       ctx.pop_type()
       ctx.push_type(AnyRef)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_any_convert_extern)
     }
     ExternConvertAny => {
       ctx.pop_type()
       ctx.push_type(ExternRef)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_extern_convert_any)
     }
     RefI31 => {
       ctx.pop_type()
       ctx.push_type(Ref(I31, false))
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_ref_i31)
     }
     I31GetS => {
       ctx.pop_type()
       ctx.push_type(I32)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_i31_get_s)
     }
     I31GetU => {
       ctx.pop_type()
       ctx.push_type(I32)
-      self.emit_fn(op_gc_unimplemented)
+      self.emit_fn(op_i31_get_u)
     }
     // Indirect call
     CallIndirect(type_idx, table_idx) => {

--- a/src/runtime/compile_helpers.mbt
+++ b/src/runtime/compile_helpers.mbt
@@ -153,6 +153,18 @@ fn storage_value_type(storage : @core.StorageType) -> @core.ValType {
 }
 
 ///|
+/// Get the byte size of a storage type
+fn storage_byte_size(storage : @core.StorageType) -> Int {
+  match storage {
+    I8 => 1
+    I16 => 2
+    Val(I32) | Val(F32) => 4
+    Val(I64) | Val(F64) => 8
+    _ => 8 // Default for reference types
+  }
+}
+
+///|
 /// Get the type index for a function (imported or local)
 /// Returns -1 if the function index is invalid
 fn get_func_type_idx(

--- a/src/runtime/ops_gc.mbt
+++ b/src/runtime/ops_gc.mbt
@@ -1,0 +1,1159 @@
+///|
+/// GC Object representation
+/// GC objects are stored in the gc_heap array
+/// Stack values use the index into gc_heap as reference (shifted by 1 to distinguish from null)
+/// Reference encoding: 0 = null, n > 0 means gc_heap[n-1]
+
+///|
+/// GC Struct instance - stores field values as UInt64 array
+pub(all) struct GcStruct {
+  type_idx : Int
+  fields : Array[UInt64]
+}
+
+///|
+/// GC Array instance - stores element values as UInt64 array
+pub(all) struct GcArray {
+  type_idx : Int
+  elements : Array[UInt64]
+}
+
+///|
+/// GC Object - either a struct or an array
+pub(all) enum GcObject {
+  Struct(GcStruct)
+  Array(GcArray)
+  I31(Int) // i31ref - 31-bit integer as reference
+}
+
+// =============================================================================
+// GC Heap operations
+// =============================================================================
+
+///|
+/// Allocate a new struct on the GC heap
+fn gc_alloc_struct(rt : Runtime, type_idx : Int, fields : Array[UInt64]) -> Int {
+  let obj = GcObject::Struct({ type_idx, fields })
+  rt.ctx.gc_heap.push(obj)
+  rt.ctx.gc_heap.length() // 1-based index (0 = null)
+}
+
+///|
+/// Allocate a new array on the GC heap
+fn gc_alloc_array(rt : Runtime, type_idx : Int, elements : Array[UInt64]) -> Int {
+  let obj = GcObject::Array({ type_idx, elements })
+  rt.ctx.gc_heap.push(obj)
+  rt.ctx.gc_heap.length() // 1-based index (0 = null)
+}
+
+///|
+/// Get a GC object by reference (1-based, 0 = null)
+fn gc_get_object(rt : Runtime, ref_value : Int) -> GcObject? {
+  if ref_value <= 0 {
+    None
+  } else if ref_value > rt.ctx.gc_heap.length() {
+    None
+  } else {
+    Some(rt.ctx.gc_heap[ref_value - 1])
+  }
+}
+
+// =============================================================================
+// Struct operations
+// =============================================================================
+
+///|
+/// struct.new type_idx
+/// Pops field values from stack, creates new struct
+fn op_struct_new(rt : Runtime) -> Runtime {
+  let type_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let num_fields = rt.ops.unsafe_get(rt.pc + 2).to_int()
+
+  // Pop field values from stack (in reverse order)
+  let fields : Array[UInt64] = Array::make(num_fields, 0UL)
+  let mut sp = rt.sp
+  for i = num_fields - 1; i >= 0; i = i - 1 {
+    sp = sp - 1
+    fields[i] = rt.stack.unsafe_get(sp)
+  }
+
+  // Allocate struct
+  let ref_value = gc_alloc_struct(rt, type_idx, fields)
+
+  // Push reference
+  rt.stack.unsafe_set(sp, ref_value.to_uint64())
+  { ..rt, sp: sp + 1, pc: rt.pc + 3 }
+}
+
+///|
+/// struct.new_default type_idx
+/// Creates a new struct with default (zero) values
+fn op_struct_new_default(rt : Runtime) -> Runtime {
+  let type_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let num_fields = rt.ops.unsafe_get(rt.pc + 2).to_int()
+
+  // Create fields with default values (all zeros)
+  let fields : Array[UInt64] = Array::make(num_fields, 0UL)
+
+  // Allocate struct
+  let ref_value = gc_alloc_struct(rt, type_idx, fields)
+
+  // Push reference
+  rt.stack.unsafe_set(rt.sp, ref_value.to_uint64())
+  { ..rt, sp: rt.sp + 1, pc: rt.pc + 3 }
+}
+
+///|
+/// struct.get type_idx field_idx
+/// Pops struct ref, pushes field value
+fn op_struct_get(rt : Runtime) -> Runtime {
+  let field_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+
+  let sp = rt.sp - 1
+  let ref_value = rt.stack.unsafe_get(sp).to_int()
+
+  // Null check
+  if ref_value == 0 {
+    rt.ctx.error_detail = "struct.get: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, ref_value) {
+    Some(Struct(s)) => {
+      let value = s.fields[field_idx]
+      rt.stack.unsafe_set(sp, value)
+      { ..rt, sp: sp + 1, pc: rt.pc + 2 }
+    }
+    _ => {
+      rt.ctx.error_detail = "struct.get: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+///|
+/// struct.get_s type_idx field_idx (sign-extend packed field)
+fn op_struct_get_s(rt : Runtime) -> Runtime {
+  let field_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let storage_type = rt.ops.unsafe_get(rt.pc + 2).to_int() // 0=i8, 1=i16
+
+  let sp = rt.sp - 1
+  let ref_value = rt.stack.unsafe_get(sp).to_int()
+
+  if ref_value == 0 {
+    rt.ctx.error_detail = "struct.get_s: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, ref_value) {
+    Some(Struct(s)) => {
+      let raw_value = s.fields[field_idx].to_uint()
+      let signed_value = if storage_type == 0 {
+        // i8 sign extend
+        let v = raw_value.land(0xFFU)
+        if v.land(0x80U) != 0U {
+          v.lor(0xFFFFFF00U)
+        } else {
+          v
+        }
+      } else {
+        // i16 sign extend
+        let v = raw_value.land(0xFFFFU)
+        if v.land(0x8000U) != 0U {
+          v.lor(0xFFFF0000U)
+        } else {
+          v
+        }
+      }
+      rt.stack.unsafe_set(sp, signed_value.to_uint64())
+      { ..rt, sp: sp + 1, pc: rt.pc + 3 }
+    }
+    _ => {
+      rt.ctx.error_detail = "struct.get_s: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+///|
+/// struct.get_u type_idx field_idx (zero-extend packed field)
+fn op_struct_get_u(rt : Runtime) -> Runtime {
+  let field_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let storage_type = rt.ops.unsafe_get(rt.pc + 2).to_int() // 0=i8, 1=i16
+
+  let sp = rt.sp - 1
+  let ref_value = rt.stack.unsafe_get(sp).to_int()
+
+  if ref_value == 0 {
+    rt.ctx.error_detail = "struct.get_u: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, ref_value) {
+    Some(Struct(s)) => {
+      let raw_value = s.fields[field_idx].to_uint()
+      let value = if storage_type == 0 {
+        raw_value.land(0xFFU) // i8
+      } else {
+        raw_value.land(0xFFFFU) // i16
+      }
+      rt.stack.unsafe_set(sp, value.to_uint64())
+      { ..rt, sp: sp + 1, pc: rt.pc + 3 }
+    }
+    _ => {
+      rt.ctx.error_detail = "struct.get_u: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+///|
+/// struct.set type_idx field_idx
+/// Pops struct ref and value, sets field
+fn op_struct_set(rt : Runtime) -> Runtime {
+  let field_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+
+  let sp = rt.sp - 2
+  let ref_value = rt.stack.unsafe_get(sp).to_int()
+  let value = rt.stack.unsafe_get(sp + 1)
+
+  if ref_value == 0 {
+    rt.ctx.error_detail = "struct.set: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, ref_value) {
+    Some(Struct(s)) => {
+      s.fields[field_idx] = value
+      { ..rt, sp, pc: rt.pc + 2 }
+    }
+    _ => {
+      rt.ctx.error_detail = "struct.set: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+// =============================================================================
+// Array operations
+// =============================================================================
+
+///|
+/// array.new type_idx
+/// Pops value and length, creates new array filled with value
+fn op_array_new(rt : Runtime) -> Runtime {
+  let type_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+
+  let sp = rt.sp - 2
+  let init_value = rt.stack.unsafe_get(sp)
+  let length = rt.stack.unsafe_get(sp + 1).to_int()
+
+  let elements = Array::make(length, init_value)
+  let ref_value = gc_alloc_array(rt, type_idx, elements)
+
+  rt.stack.unsafe_set(sp, ref_value.to_uint64())
+  { ..rt, sp: sp + 1, pc: rt.pc + 2 }
+}
+
+///|
+/// array.new_default type_idx
+/// Pops length, creates new array with default values
+fn op_array_new_default(rt : Runtime) -> Runtime {
+  let type_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+
+  let sp = rt.sp - 1
+  let length = rt.stack.unsafe_get(sp).to_int()
+
+  let elements : Array[UInt64] = Array::make(length, 0UL)
+  let ref_value = gc_alloc_array(rt, type_idx, elements)
+
+  rt.stack.unsafe_set(sp, ref_value.to_uint64())
+  { ..rt, sp: sp + 1, pc: rt.pc + 2 }
+}
+
+///|
+/// array.new_fixed type_idx length
+/// Pops length values from stack, creates array
+fn op_array_new_fixed(rt : Runtime) -> Runtime {
+  let type_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let length = rt.ops.unsafe_get(rt.pc + 2).to_int()
+
+  let elements : Array[UInt64] = Array::make(length, 0UL)
+  let mut sp = rt.sp
+  for i = length - 1; i >= 0; i = i - 1 {
+    sp = sp - 1
+    elements[i] = rt.stack.unsafe_get(sp)
+  }
+
+  let ref_value = gc_alloc_array(rt, type_idx, elements)
+  rt.stack.unsafe_set(sp, ref_value.to_uint64())
+  { ..rt, sp: sp + 1, pc: rt.pc + 3 }
+}
+
+///|
+/// array.new_data type_idx data_idx
+/// Pops offset and length, creates array from data segment
+fn op_array_new_data(rt : Runtime) -> Runtime {
+  let type_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let data_idx = rt.ops.unsafe_get(rt.pc + 2).to_int()
+  let elem_size = rt.ops.unsafe_get(rt.pc + 3).to_int() // 1, 2, 4, or 8 bytes
+
+  let sp = rt.sp - 2
+  let offset = rt.stack.unsafe_get(sp).to_int()
+  let length = rt.stack.unsafe_get(sp + 1).to_int()
+
+  // Get data segment
+  if data_idx < 0 || data_idx >= rt.ctx.data_segments.length() {
+    rt.ctx.error_detail = "array.new_data: invalid data segment index"
+    return { ..rt, status: Trap }
+  }
+  let data = rt.ctx.data_segments[data_idx]
+
+  // Bounds check
+  if offset < 0 || offset + length * elem_size > data.length() {
+    rt.ctx.error_detail = "array.new_data: out of bounds"
+    return { ..rt, status: Trap }
+  }
+
+  // Create array elements from data segment
+  let elements : Array[UInt64] = Array::make(length, 0UL)
+  for i = 0; i < length; i = i + 1 {
+    let byte_offset = offset + i * elem_size
+    let mut value = 0UL
+    for j = 0; j < elem_size; j = j + 1 {
+      value = value.lor(data[byte_offset + j].to_uint64() << (j * 8))
+    }
+    elements[i] = value
+  }
+
+  let ref_value = gc_alloc_array(rt, type_idx, elements)
+  rt.stack.unsafe_set(sp, ref_value.to_uint64())
+  { ..rt, sp: sp + 1, pc: rt.pc + 4 }
+}
+
+///|
+/// array.get type_idx
+/// Pops array ref and index, pushes element
+fn op_array_get(rt : Runtime) -> Runtime {
+  let sp = rt.sp - 2
+  let ref_value = rt.stack.unsafe_get(sp).to_int()
+  let index = rt.stack.unsafe_get(sp + 1).to_int()
+
+  if ref_value == 0 {
+    rt.ctx.error_detail = "array.get: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, ref_value) {
+    Some(Array(a)) => {
+      if index < 0 || index >= a.elements.length() {
+        rt.ctx.error_detail = "array.get: index out of bounds"
+        return { ..rt, status: Trap }
+      }
+      let value = a.elements[index]
+      rt.stack.unsafe_set(sp, value)
+      { ..rt, sp: sp + 1, pc: rt.pc + 1 }
+    }
+    _ => {
+      rt.ctx.error_detail = "array.get: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+///|
+/// array.get_s type_idx (sign-extend packed element)
+fn op_array_get_s(rt : Runtime) -> Runtime {
+  let storage_type = rt.ops.unsafe_get(rt.pc + 1).to_int() // 0=i8, 1=i16
+
+  let sp = rt.sp - 2
+  let ref_value = rt.stack.unsafe_get(sp).to_int()
+  let index = rt.stack.unsafe_get(sp + 1).to_int()
+
+  if ref_value == 0 {
+    rt.ctx.error_detail = "array.get_s: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, ref_value) {
+    Some(Array(a)) => {
+      if index < 0 || index >= a.elements.length() {
+        rt.ctx.error_detail = "array.get_s: index out of bounds"
+        return { ..rt, status: Trap }
+      }
+      let raw_value = a.elements[index].to_uint()
+      let signed_value = if storage_type == 0 {
+        let v = raw_value.land(0xFFU)
+        if v.land(0x80U) != 0U { v.lor(0xFFFFFF00U) } else { v }
+      } else {
+        let v = raw_value.land(0xFFFFU)
+        if v.land(0x8000U) != 0U { v.lor(0xFFFF0000U) } else { v }
+      }
+      rt.stack.unsafe_set(sp, signed_value.to_uint64())
+      { ..rt, sp: sp + 1, pc: rt.pc + 2 }
+    }
+    _ => {
+      rt.ctx.error_detail = "array.get_s: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+///|
+/// array.get_u type_idx (zero-extend packed element)
+fn op_array_get_u(rt : Runtime) -> Runtime {
+  let storage_type = rt.ops.unsafe_get(rt.pc + 1).to_int() // 0=i8, 1=i16
+
+  let sp = rt.sp - 2
+  let ref_value = rt.stack.unsafe_get(sp).to_int()
+  let index = rt.stack.unsafe_get(sp + 1).to_int()
+
+  if ref_value == 0 {
+    rt.ctx.error_detail = "array.get_u: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, ref_value) {
+    Some(Array(a)) => {
+      if index < 0 || index >= a.elements.length() {
+        rt.ctx.error_detail = "array.get_u: index out of bounds"
+        return { ..rt, status: Trap }
+      }
+      let raw_value = a.elements[index].to_uint()
+      let value = if storage_type == 0 {
+        raw_value.land(0xFFU)
+      } else {
+        raw_value.land(0xFFFFU)
+      }
+      rt.stack.unsafe_set(sp, value.to_uint64())
+      { ..rt, sp: sp + 1, pc: rt.pc + 2 }
+    }
+    _ => {
+      rt.ctx.error_detail = "array.get_u: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+///|
+/// array.set type_idx
+/// Pops array ref, index, and value, sets element
+fn op_array_set(rt : Runtime) -> Runtime {
+  let sp = rt.sp - 3
+  let ref_value = rt.stack.unsafe_get(sp).to_int()
+  let index = rt.stack.unsafe_get(sp + 1).to_int()
+  let value = rt.stack.unsafe_get(sp + 2)
+
+  if ref_value == 0 {
+    rt.ctx.error_detail = "array.set: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, ref_value) {
+    Some(Array(a)) => {
+      if index < 0 || index >= a.elements.length() {
+        rt.ctx.error_detail = "array.set: index out of bounds"
+        return { ..rt, status: Trap }
+      }
+      a.elements[index] = value
+      { ..rt, sp, pc: rt.pc + 1 }
+    }
+    _ => {
+      rt.ctx.error_detail = "array.set: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+///|
+/// array.len
+/// Pops array ref, pushes length
+fn op_array_len(rt : Runtime) -> Runtime {
+  let sp = rt.sp - 1
+  let ref_value = rt.stack.unsafe_get(sp).to_int()
+
+  if ref_value == 0 {
+    rt.ctx.error_detail = "array.len: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, ref_value) {
+    Some(Array(a)) => {
+      let len = a.elements.length()
+      rt.stack.unsafe_set(sp, len.to_uint64())
+      { ..rt, sp: sp + 1, pc: rt.pc + 1 }
+    }
+    _ => {
+      rt.ctx.error_detail = "array.len: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+///|
+/// array.fill type_idx
+/// Pops array, offset, value, length and fills the array
+fn op_array_fill(rt : Runtime) -> Runtime {
+  let sp = rt.sp - 4
+  let ref_value = rt.stack.unsafe_get(sp).to_int()
+  let offset = rt.stack.unsafe_get(sp + 1).to_int()
+  let value = rt.stack.unsafe_get(sp + 2)
+  let length = rt.stack.unsafe_get(sp + 3).to_int()
+
+  if ref_value == 0 {
+    rt.ctx.error_detail = "array.fill: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, ref_value) {
+    Some(Array(a)) => {
+      if offset < 0 || offset + length > a.elements.length() {
+        rt.ctx.error_detail = "array.fill: out of bounds"
+        return { ..rt, status: Trap }
+      }
+      for i = 0; i < length; i = i + 1 {
+        a.elements[offset + i] = value
+      }
+      { ..rt, sp, pc: rt.pc + 1 }
+    }
+    _ => {
+      rt.ctx.error_detail = "array.fill: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+///|
+/// array.copy dst_type src_type
+/// Copies elements from src array to dst array
+fn op_array_copy(rt : Runtime) -> Runtime {
+  let sp = rt.sp - 5
+  let dst_ref = rt.stack.unsafe_get(sp).to_int()
+  let dst_offset = rt.stack.unsafe_get(sp + 1).to_int()
+  let src_ref = rt.stack.unsafe_get(sp + 2).to_int()
+  let src_offset = rt.stack.unsafe_get(sp + 3).to_int()
+  let length = rt.stack.unsafe_get(sp + 4).to_int()
+
+  if dst_ref == 0 || src_ref == 0 {
+    rt.ctx.error_detail = "array.copy: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  match (gc_get_object(rt, dst_ref), gc_get_object(rt, src_ref)) {
+    (Some(Array(dst)), Some(Array(src))) => {
+      if dst_offset < 0 ||
+        dst_offset + length > dst.elements.length() ||
+        src_offset < 0 ||
+        src_offset + length > src.elements.length() {
+        rt.ctx.error_detail = "array.copy: out of bounds"
+        return { ..rt, status: Trap }
+      }
+      // Handle overlapping regions
+      if dst_ref == src_ref && dst_offset > src_offset {
+        for i = length - 1; i >= 0; i = i - 1 {
+          dst.elements[dst_offset + i] = src.elements[src_offset + i]
+        }
+      } else {
+        for i = 0; i < length; i = i + 1 {
+          dst.elements[dst_offset + i] = src.elements[src_offset + i]
+        }
+      }
+      { ..rt, sp, pc: rt.pc + 1 }
+    }
+    _ => {
+      rt.ctx.error_detail = "array.copy: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+// =============================================================================
+// i31 operations
+// =============================================================================
+
+///|
+/// ref.i31
+/// Pops i32, pushes i31ref (31-bit signed integer as reference)
+fn op_ref_i31(rt : Runtime) -> Runtime {
+  let sp = rt.sp - 1
+  let value = rt.stack.unsafe_get(sp).to_uint()
+
+  // i31 is a 31-bit signed integer stored as a special reference
+  // Encode as: (value << 1) | 1 to distinguish from GC heap references
+  let i31_value = value.land(0x7FFFFFFFU)
+  let encoded = (i31_value << 1).lor(1U)
+
+  rt.stack.unsafe_set(sp, encoded.to_uint64())
+  { ..rt, sp: sp + 1, pc: rt.pc + 1 }
+}
+
+///|
+/// i31.get_s
+/// Pops i31ref, pushes sign-extended i32
+fn op_i31_get_s(rt : Runtime) -> Runtime {
+  let sp = rt.sp - 1
+  let encoded = rt.stack.unsafe_get(sp).to_uint()
+
+  // Check if it's a valid i31ref (lowest bit set)
+  if encoded.land(1U) != 1U {
+    rt.ctx.error_detail = "i31.get_s: not an i31ref"
+    return { ..rt, status: Trap }
+  }
+
+  // Decode: (encoded >> 1) with sign extension from bit 30
+  let raw = encoded >> 1
+  let signed : UInt = if raw.land(0x40000000U) != 0U {
+    raw.lor(0x80000000U) // Sign extend from bit 30
+  } else {
+    raw
+  }
+
+  rt.stack.unsafe_set(sp, signed.to_uint64())
+  { ..rt, sp: sp + 1, pc: rt.pc + 1 }
+}
+
+///|
+/// i31.get_u
+/// Pops i31ref, pushes zero-extended i32
+fn op_i31_get_u(rt : Runtime) -> Runtime {
+  let sp = rt.sp - 1
+  let encoded = rt.stack.unsafe_get(sp).to_uint()
+
+  // Check if it's a valid i31ref
+  if encoded.land(1U) != 1U {
+    rt.ctx.error_detail = "i31.get_u: not an i31ref"
+    return { ..rt, status: Trap }
+  }
+
+  // Decode: (encoded >> 1) masked to 31 bits
+  let value = (encoded >> 1).land(0x7FFFFFFFU)
+
+  rt.stack.unsafe_set(sp, value.to_uint64())
+  { ..rt, sp: sp + 1, pc: rt.pc + 1 }
+}
+
+// =============================================================================
+// Reference conversion operations
+// =============================================================================
+
+///|
+/// any.convert_extern
+/// Converts externref to anyref (no-op in our implementation)
+fn op_any_convert_extern(rt : Runtime) -> Runtime {
+  // externref and anyref use the same representation in our implementation
+  { ..rt, pc: rt.pc + 1 }
+}
+
+///|
+/// extern.convert_any
+/// Converts anyref to externref (no-op in our implementation)
+fn op_extern_convert_any(rt : Runtime) -> Runtime {
+  // externref and anyref use the same representation in our implementation
+  { ..rt, pc: rt.pc + 1 }
+}
+
+// =============================================================================
+// Reference null/test operations
+// =============================================================================
+
+// Note: op_ref_null, op_ref_is_null, op_ref_as_non_null, and op_ref_eq
+// are already defined in ops_control.mbt
+
+// =============================================================================
+// Runtime type checking helpers
+// =============================================================================
+
+///|
+/// Check if a GC object reference matches or is a subtype of a target heap type
+/// Returns true if the reference can be cast to the target type
+fn gc_ref_matches_type(
+  rt : Runtime,
+  ref_value : UInt64,
+  target_type : Int,
+  target_nullable : Bool,
+) -> Bool {
+  // Check for null reference
+  if ref_value == 0UL {
+    return target_nullable
+  }
+
+  // Check for i31ref (encoded with lowest bit set)
+  if ref_value.land(1UL) == 1UL {
+    // i31ref: check if target is i31, eq, or any
+    return target_type == -4 || // I31
+      target_type == -3 || // Eq
+      target_type == -2 // Any
+  }
+
+  // Get the GC object
+  let ref_int = ref_value.to_int()
+  match gc_get_object(rt, ref_int) {
+    Some(Struct(s)) =>
+      // Struct reference: check if s.type_idx matches target
+      if target_type >= 0 {
+        // Target is a concrete type index
+        gc_is_type_subtype(rt, s.type_idx, target_type)
+      } else {
+        // Target is an abstract type (-5=Struct, -3=Eq, -2=Any)
+        target_type == -5 || target_type == -3 || target_type == -2
+      }
+    Some(Array(a)) =>
+      // Array reference: check if a.type_idx matches target
+      if target_type >= 0 {
+        gc_is_type_subtype(rt, a.type_idx, target_type)
+      } else {
+        // Target is an abstract type (-6=Array, -3=Eq, -2=Any)
+        target_type == -6 || target_type == -3 || target_type == -2
+      }
+    Some(I31(_)) =>
+      // I31 value: check if target is i31, eq, or any
+      target_type == -4 || target_type == -3 || target_type == -2
+    None => false
+  }
+}
+
+///|
+/// Check if type_idx is a subtype of target_type_idx at runtime
+/// This mirrors the validation-time is_type_index_subtype function
+fn gc_is_type_subtype(rt : Runtime, type_idx : Int, target_type_idx : Int) -> Bool {
+  if type_idx == target_type_idx {
+    return true
+  }
+
+  let module_ = rt.ctx.module_
+
+  // Search through type_groups for supertype declarations
+  for group in module_.type_groups {
+    for subtype_def in group.subtypes {
+      let current_idx = subtype_def.type_idx.reinterpret_as_int()
+      if current_idx == type_idx {
+        for supertype in subtype_def.supertypes {
+          let super_idx = supertype.reinterpret_as_int()
+          if super_idx == target_type_idx {
+            return true
+          }
+          if gc_is_type_subtype(rt, super_idx, target_type_idx) {
+            return true
+          }
+        }
+      }
+    }
+  }
+
+  // Check structural subtyping
+  if type_idx >= 0 &&
+    type_idx < module_.types.length() &&
+    target_type_idx >= 0 &&
+    target_type_idx < module_.types.length() {
+    match (module_.types[type_idx], module_.types[target_type_idx]) {
+      (Struct(s1), Struct(s2)) => return gc_is_struct_subtype(rt, s1, s2)
+      (Array(a1), Array(a2)) => return gc_is_array_subtype(rt, a1, a2)
+      _ => ()
+    }
+  }
+
+  false
+}
+
+///|
+/// Check structural subtyping for struct types at runtime
+fn gc_is_struct_subtype(
+  rt : Runtime,
+  struct1 : @core.StructType,
+  struct2 : @core.StructType,
+) -> Bool {
+  if struct2.fields.length() > struct1.fields.length() {
+    return false
+  }
+
+  for i in 0..<struct2.fields.length() {
+    let f1 = struct1.fields[i]
+    let f2 = struct2.fields[i]
+
+    if f1.mutable != f2.mutable {
+      return false
+    }
+
+    if not(gc_is_storage_type_subtype(rt, f1.storage, f2.storage, f1.mutable)) {
+      return false
+    }
+  }
+
+  true
+}
+
+///|
+/// Check structural subtyping for array types at runtime
+fn gc_is_array_subtype(
+  rt : Runtime,
+  arr1 : @core.ArrayType,
+  arr2 : @core.ArrayType,
+) -> Bool {
+  if arr1.element.mutable != arr2.element.mutable {
+    return false
+  }
+  gc_is_storage_type_subtype(
+    rt,
+    arr1.element.storage,
+    arr2.element.storage,
+    arr1.element.mutable,
+  )
+}
+
+///|
+/// Check storage type subtyping at runtime
+fn gc_is_storage_type_subtype(
+  rt : Runtime,
+  storage1 : @core.StorageType,
+  storage2 : @core.StorageType,
+  mutable : Bool,
+) -> Bool {
+  match (storage1, storage2) {
+    (Val(v1), Val(v2)) =>
+      if mutable {
+        v1 == v2
+      } else {
+        gc_is_valtype_subtype(rt, v1, v2)
+      }
+    (I8, I8) | (I16, I16) => true
+    _ => false
+  }
+}
+
+///|
+/// Check value type subtyping at runtime
+fn gc_is_valtype_subtype(
+  rt : Runtime,
+  t1 : @core.ValType,
+  t2 : @core.ValType,
+) -> Bool {
+  if t1 == t2 {
+    return true
+  }
+  match (t1, t2) {
+    (Ref(TypeIndex(n1), _), Ref(TypeIndex(n2), _)) =>
+      gc_is_type_subtype(rt, n1, n2)
+    (Ref(_, false), Ref(ht, true)) => t1 == Ref(ht, false)
+    (I31Ref, EqRef) | (I31Ref, AnyRef) => true
+    (StructRef, EqRef) | (StructRef, AnyRef) => true
+    (ArrayRef, EqRef) | (ArrayRef, AnyRef) => true
+    (EqRef, AnyRef) => true
+    _ => false
+  }
+}
+
+///|
+/// Convert heap type code to type index for runtime checking
+/// Negative values represent abstract types:
+/// -2 = Any, -3 = Eq, -4 = I31, -5 = Struct, -6 = Array, -7 = Func, -8 = Extern
+fn heap_type_to_target_type(heap_type_code : Int) -> Int {
+  match heap_type_code {
+    0 => -7 // Func
+    1 => -8 // Extern
+    2 => -2 // Any
+    3 => -3 // Eq
+    4 => -4 // I31
+    5 => -5 // Struct
+    6 => -6 // Array
+    _ => heap_type_code // TypeIndex (positive values)
+  }
+}
+
+// =============================================================================
+// ref.test / ref.cast operations
+// =============================================================================
+
+///|
+/// ref.test heap_type nullable
+/// Tests if a reference is of the given type, pushes i32 result
+fn op_ref_test(rt : Runtime) -> Runtime {
+  let target_type = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let target_nullable = rt.ops.unsafe_get(rt.pc + 2).to_int() != 0
+
+  let sp = rt.sp - 1
+  let ref_value = rt.stack.unsafe_get(sp)
+
+  let result = if gc_ref_matches_type(rt, ref_value, target_type, target_nullable) {
+    1U
+  } else {
+    0U
+  }
+
+  rt.stack.unsafe_set(sp, result.to_uint64())
+  { ..rt, sp: sp + 1, pc: rt.pc + 3 }
+}
+
+///|
+/// ref.cast heap_type nullable
+/// Casts a reference to the given type, traps on failure
+fn op_ref_cast(rt : Runtime) -> Runtime {
+  let target_type = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let target_nullable = rt.ops.unsafe_get(rt.pc + 2).to_int() != 0
+
+  let sp = rt.sp - 1
+  let ref_value = rt.stack.unsafe_get(sp)
+
+  if gc_ref_matches_type(rt, ref_value, target_type, target_nullable) {
+    // Cast succeeds - leave value on stack
+    { ..rt, sp: sp + 1, pc: rt.pc + 3 }
+  } else {
+    rt.ctx.error_detail = "ref.cast: cast failed"
+    { ..rt, status: Trap }
+  }
+}
+
+// =============================================================================
+// br_on_cast operations with proper type checking
+// =============================================================================
+
+///|
+/// br_on_cast label target_type target_nullable
+fn op_br_on_cast(rt : Runtime) -> Runtime {
+  let target_pc = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let arity = rt.ops.unsafe_get(rt.pc + 2).to_int()
+  let drop_count = rt.ops.unsafe_get(rt.pc + 3).to_int()
+  let target_type = rt.ops.unsafe_get(rt.pc + 4).to_int()
+  let target_nullable = rt.ops.unsafe_get(rt.pc + 5).to_int() != 0
+
+  let sp = rt.sp - 1
+  let ref_value = rt.stack.unsafe_get(sp)
+
+  // Check if cast succeeds using proper type checking
+  let cast_succeeds = gc_ref_matches_type(
+    rt,
+    ref_value,
+    target_type,
+    target_nullable,
+  )
+
+  if cast_succeeds {
+    // Branch - copy result values and jump
+    if drop_count > 0 && arity > 0 {
+      let result_start = rt.sp - arity
+      let target_start = result_start - drop_count
+      for i = 0; i < arity; i = i + 1 {
+        rt.stack.unsafe_set(
+          target_start + i,
+          rt.stack.unsafe_get(result_start + i),
+        )
+      }
+    }
+    { ..rt, sp: rt.sp - drop_count, pc: target_pc }
+  } else {
+    // Continue - leave reference on stack
+    { ..rt, sp: sp + 1, pc: rt.pc + 6 }
+  }
+}
+
+///|
+/// br_on_cast_fail label target_type target_nullable
+fn op_br_on_cast_fail(rt : Runtime) -> Runtime {
+  let target_pc = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let arity = rt.ops.unsafe_get(rt.pc + 2).to_int()
+  let drop_count = rt.ops.unsafe_get(rt.pc + 3).to_int()
+  let target_type = rt.ops.unsafe_get(rt.pc + 4).to_int()
+  let target_nullable = rt.ops.unsafe_get(rt.pc + 5).to_int() != 0
+
+  let sp = rt.sp - 1
+  let ref_value = rt.stack.unsafe_get(sp)
+
+  // Check if cast fails using proper type checking
+  let cast_fails = not(
+    gc_ref_matches_type(rt, ref_value, target_type, target_nullable),
+  )
+
+  if cast_fails {
+    // Branch
+    if drop_count > 0 && arity > 0 {
+      let result_start = rt.sp - arity
+      let target_start = result_start - drop_count
+      for i = 0; i < arity; i = i + 1 {
+        rt.stack.unsafe_set(
+          target_start + i,
+          rt.stack.unsafe_get(result_start + i),
+        )
+      }
+    }
+    { ..rt, sp: rt.sp - drop_count, pc: target_pc }
+  } else {
+    // Continue - leave reference on stack
+    { ..rt, sp: sp + 1, pc: rt.pc + 6 }
+  }
+}
+
+// =============================================================================
+// array.new_elem, array.init_data, array.init_elem operations
+// =============================================================================
+
+///|
+/// array.new_elem type_idx elem_idx
+/// Creates a new array from element segment values
+fn op_array_new_elem(rt : Runtime) -> Runtime {
+  let type_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let elem_idx = rt.ops.unsafe_get(rt.pc + 2).to_int()
+
+  let sp = rt.sp - 2
+  let offset = rt.stack.unsafe_get(sp).to_int()
+  let length = rt.stack.unsafe_get(sp + 1).to_int()
+
+  // Get element segment from module
+  if elem_idx < 0 || elem_idx >= rt.ctx.module_.elems.length() {
+    rt.ctx.error_detail = "array.new_elem: invalid element segment index"
+    return { ..rt, status: Trap }
+  }
+  let elem = rt.ctx.module_.elems[elem_idx]
+
+  // Bounds check
+  if offset < 0 || offset + length > elem.init.length() {
+    rt.ctx.error_detail = "array.new_elem: out of bounds"
+    return { ..rt, status: Trap }
+  }
+
+  // Create array elements by evaluating element expressions
+  let elements : Array[UInt64] = Array::make(length, 0UL)
+  for i = 0; i < length; i = i + 1 {
+    let expr = elem.init[offset + i]
+    // Evaluate the element expression (typically ref.func or ref.null)
+    let value = eval_elem_expr(expr)
+    elements[i] = value
+  }
+
+  let ref_value = gc_alloc_array(rt, type_idx, elements)
+  rt.stack.unsafe_set(sp, ref_value.to_uint64())
+  { ..rt, sp: sp + 1, pc: rt.pc + 3 }
+}
+
+///|
+/// array.init_data type_idx data_idx
+/// Initializes array elements from data segment
+fn op_array_init_data(rt : Runtime) -> Runtime {
+  let type_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let data_idx = rt.ops.unsafe_get(rt.pc + 2).to_int()
+  let elem_size = rt.ops.unsafe_get(rt.pc + 3).to_int()
+
+  let sp = rt.sp - 4
+  let arr_ref = rt.stack.unsafe_get(sp).to_int()
+  let arr_offset = rt.stack.unsafe_get(sp + 1).to_int()
+  let data_offset = rt.stack.unsafe_get(sp + 2).to_int()
+  let length = rt.stack.unsafe_get(sp + 3).to_int()
+
+  if arr_ref == 0 {
+    rt.ctx.error_detail = "array.init_data: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  // Get data segment
+  if data_idx < 0 || data_idx >= rt.ctx.data_segments.length() {
+    rt.ctx.error_detail = "array.init_data: invalid data segment index"
+    return { ..rt, status: Trap }
+  }
+  let data = rt.ctx.data_segments[data_idx]
+
+  // Bounds check on data segment
+  if data_offset < 0 || data_offset + length * elem_size > data.length() {
+    rt.ctx.error_detail = "array.init_data: data segment out of bounds"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, arr_ref) {
+    Some(Array(a)) => {
+      // Bounds check on array
+      if arr_offset < 0 || arr_offset + length > a.elements.length() {
+        rt.ctx.error_detail = "array.init_data: array out of bounds"
+        return { ..rt, status: Trap }
+      }
+
+      // Copy data to array elements
+      for i = 0; i < length; i = i + 1 {
+        let byte_offset = data_offset + i * elem_size
+        let mut value = 0UL
+        for j = 0; j < elem_size; j = j + 1 {
+          value = value.lor(data[byte_offset + j].to_uint64() << (j * 8))
+        }
+        a.elements[arr_offset + i] = value
+      }
+      ignore(type_idx)
+      { ..rt, sp, pc: rt.pc + 4 }
+    }
+    _ => {
+      rt.ctx.error_detail = "array.init_data: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+///|
+/// array.init_elem type_idx elem_idx
+/// Initializes array elements from element segment
+fn op_array_init_elem(rt : Runtime) -> Runtime {
+  let type_idx = rt.ops.unsafe_get(rt.pc + 1).to_int()
+  let elem_idx = rt.ops.unsafe_get(rt.pc + 2).to_int()
+
+  let sp = rt.sp - 4
+  let arr_ref = rt.stack.unsafe_get(sp).to_int()
+  let arr_offset = rt.stack.unsafe_get(sp + 1).to_int()
+  let elem_offset = rt.stack.unsafe_get(sp + 2).to_int()
+  let length = rt.stack.unsafe_get(sp + 3).to_int()
+
+  if arr_ref == 0 {
+    rt.ctx.error_detail = "array.init_elem: null reference"
+    return { ..rt, status: Trap }
+  }
+
+  // Get element segment
+  if elem_idx < 0 || elem_idx >= rt.ctx.module_.elems.length() {
+    rt.ctx.error_detail = "array.init_elem: invalid element segment index"
+    return { ..rt, status: Trap }
+  }
+  let elem = rt.ctx.module_.elems[elem_idx]
+
+  // Bounds check on element segment
+  if elem_offset < 0 || elem_offset + length > elem.init.length() {
+    rt.ctx.error_detail = "array.init_elem: element segment out of bounds"
+    return { ..rt, status: Trap }
+  }
+
+  match gc_get_object(rt, arr_ref) {
+    Some(Array(a)) => {
+      // Bounds check on array
+      if arr_offset < 0 || arr_offset + length > a.elements.length() {
+        rt.ctx.error_detail = "array.init_elem: array out of bounds"
+        return { ..rt, status: Trap }
+      }
+
+      // Copy element expressions to array elements
+      for i = 0; i < length; i = i + 1 {
+        let expr = elem.init[elem_offset + i]
+        let value = eval_elem_expr(expr)
+        a.elements[arr_offset + i] = value
+      }
+      ignore(type_idx)
+      { ..rt, sp, pc: rt.pc + 3 }
+    }
+    _ => {
+      rt.ctx.error_detail = "array.init_elem: invalid reference"
+      { ..rt, status: Trap }
+    }
+  }
+}
+
+///|
+/// Evaluate an element segment expression to get a reference value
+fn eval_elem_expr(expr : @core.Expr) -> UInt64 {
+  // Element expressions are typically simple: ref.func or ref.null
+  for instr in expr.instrs {
+    match instr {
+      RefFunc(idx) =>
+        // Function reference - return the function index
+        return idx.to_uint64()
+      RefNull(_) =>
+        // Null reference
+        return 0UL
+      I32Const(v) => return v.to_uint64()
+      I64Const(v) => return v
+      _ => ()
+    }
+  }
+  // Default to null if expression is not recognized
+  0UL
+}

--- a/src/runtime/runtime.mbt
+++ b/src/runtime/runtime.mbt
@@ -399,10 +399,13 @@ pub fn Runtime::load_with_resolver(
       _ => ()
     }
   }
+  // Create GC heap for const expr evaluation (for globals that use GC instructions)
+  let gc_heap : Array[GcObject] = []
+
   // Then add local globals
   for i in 0..<m.globals.length() {
     let global = m.globals[i]
-    let value = eval_const_expr(global.init, globals)
+    let value = eval_const_expr_with_gc(global.init, globals, gc_heap, m)
     globals.push(value)
   }
   // Initialize data segments (copy data into memory)
@@ -529,9 +532,9 @@ pub fn Runtime::load_with_resolver(
   let compiler = Compiler::new(m)
   compiler.compile()
 
-  // Create RuntimeContext with cold data
-  let ctx = RuntimeContext::new(
-    m, memory, memory_max_pages, globals, tables, imported_funcs, data_segments,
+  // Create RuntimeContext with cold data (including gc_heap from const expr evaluation)
+  let ctx = RuntimeContext::new_with_gc_heap(
+    m, memory, memory_max_pages, globals, tables, imported_funcs, data_segments, gc_heap,
   )
   Runtime::{
     ops: compiler.finish(),
@@ -546,9 +549,38 @@ pub fn Runtime::load_with_resolver(
 }
 
 ///|
+/// Constant expression evaluator context - holds gc_heap for GC const exprs
+priv struct ConstExprContext {
+  gc_heap : Array[GcObject]
+  module_ : @core.Module?
+}
+
+///|
 fn eval_const_expr(
   expr : @core.Expr,
   globals : Array[Value],
+) -> Value raise RuntimeError {
+  // Create empty GC heap for simple cases that don't need it
+  let ctx = ConstExprContext::{ gc_heap: [], module_: None }
+  eval_const_expr_with_context(expr, globals, ctx)
+}
+
+///|
+fn eval_const_expr_with_gc(
+  expr : @core.Expr,
+  globals : Array[Value],
+  gc_heap : Array[GcObject],
+  module_ : @core.Module,
+) -> Value raise RuntimeError {
+  let ctx = ConstExprContext::{ gc_heap, module_: Some(module_) }
+  eval_const_expr_with_context(expr, globals, ctx)
+}
+
+///|
+fn eval_const_expr_with_context(
+  expr : @core.Expr,
+  globals : Array[Value],
+  ctx : ConstExprContext,
 ) -> Value raise RuntimeError {
   // Constant expression evaluator for init expressions
   // Supports multi-instruction expressions (e.g., arithmetic in global inits)
@@ -640,6 +672,119 @@ fn eval_const_expr(
               "type mismatch in i64.mul",
             )
         }
+      }
+      // GC instructions for constant expressions
+      StructNew(type_idx) => {
+        let type_idx_int = type_idx.reinterpret_as_int()
+        let num_fields = match ctx.module_ {
+          Some(m) =>
+            match m.types.get(type_idx_int) {
+              Some(Struct(s)) => s.fields.length()
+              _ => 0
+            }
+          None => 0
+        }
+        let fields : Array[UInt64] = Array::make(num_fields, 0UL)
+        for i = num_fields - 1; i >= 0; i = i - 1 {
+          match stack.unsafe_pop() {
+            I32(v) => fields[i] = v.to_uint64()
+            I64(v) => fields[i] = v
+            F32(v) => fields[i] = v.reinterpret_as_uint().to_uint64()
+            F64(v) => fields[i] = v.reinterpret_as_uint64()
+            Ref(r) =>
+              fields[i] = match r {
+                Some(idx) => idx.to_uint64()
+                None => 0UL
+              }
+          }
+        }
+        let obj = GcObject::Struct({ type_idx: type_idx_int, fields })
+        ctx.gc_heap.push(obj)
+        let ref_value = ctx.gc_heap.length() // 1-based index
+        stack.push(Ref(Some(ref_value)))
+      }
+      StructNewDefault(type_idx) => {
+        let type_idx_int = type_idx.reinterpret_as_int()
+        let num_fields = match ctx.module_ {
+          Some(m) =>
+            match m.types.get(type_idx_int) {
+              Some(Struct(s)) => s.fields.length()
+              _ => 0
+            }
+          None => 0
+        }
+        let fields : Array[UInt64] = Array::make(num_fields, 0UL)
+        let obj = GcObject::Struct({ type_idx: type_idx_int, fields })
+        ctx.gc_heap.push(obj)
+        let ref_value = ctx.gc_heap.length()
+        stack.push(Ref(Some(ref_value)))
+      }
+      ArrayNew(type_idx) => {
+        let type_idx_int = type_idx.reinterpret_as_int()
+        let length = match stack.unsafe_pop() {
+          I32(v) => v.reinterpret_as_int()
+          _ => 0
+        }
+        let init_value = match stack.unsafe_pop() {
+          I32(v) => v.to_uint64()
+          I64(v) => v
+          F32(v) => v.reinterpret_as_uint().to_uint64()
+          F64(v) => v.reinterpret_as_uint64()
+          Ref(r) =>
+            match r {
+              Some(idx) => idx.to_uint64()
+              None => 0UL
+            }
+        }
+        let elements = Array::make(length, init_value)
+        let obj = GcObject::Array({ type_idx: type_idx_int, elements })
+        ctx.gc_heap.push(obj)
+        let ref_value = ctx.gc_heap.length()
+        stack.push(Ref(Some(ref_value)))
+      }
+      ArrayNewDefault(type_idx) => {
+        let type_idx_int = type_idx.reinterpret_as_int()
+        let length = match stack.unsafe_pop() {
+          I32(v) => v.reinterpret_as_int()
+          _ => 0
+        }
+        let elements : Array[UInt64] = Array::make(length, 0UL)
+        let obj = GcObject::Array({ type_idx: type_idx_int, elements })
+        ctx.gc_heap.push(obj)
+        let ref_value = ctx.gc_heap.length()
+        stack.push(Ref(Some(ref_value)))
+      }
+      ArrayNewFixed(type_idx, len) => {
+        let type_idx_int = type_idx.reinterpret_as_int()
+        let length = len.reinterpret_as_int()
+        let elements : Array[UInt64] = Array::make(length, 0UL)
+        for i = length - 1; i >= 0; i = i - 1 {
+          match stack.unsafe_pop() {
+            I32(v) => elements[i] = v.to_uint64()
+            I64(v) => elements[i] = v
+            F32(v) => elements[i] = v.reinterpret_as_uint().to_uint64()
+            F64(v) => elements[i] = v.reinterpret_as_uint64()
+            Ref(r) =>
+              elements[i] = match r {
+                Some(idx) => idx.to_uint64()
+                None => 0UL
+              }
+          }
+        }
+        let obj = GcObject::Array({ type_idx: type_idx_int, elements })
+        ctx.gc_heap.push(obj)
+        let ref_value = ctx.gc_heap.length()
+        stack.push(Ref(Some(ref_value)))
+      }
+      RefI31 => {
+        let value = match stack.unsafe_pop() {
+          I32(v) => v.reinterpret_as_int()
+          _ => 0
+        }
+        // Encode i31ref: (value << 1) | 1
+        let i31_value = value.land(0x7FFFFFFF)
+        let encoded = (i31_value << 1).lor(1)
+        stack.push(Ref(Some(encoded)))
       }
       _ =>
         raise RuntimeError::UnsupportedInitExpression(

--- a/src/runtime/runtime_context.mbt
+++ b/src/runtime/runtime_context.mbt
@@ -9,6 +9,7 @@ pub struct RuntimeContext {
   tables : Array[RuntimeTable]
   imported_funcs : Array[ImportedFunc]
   data_segments : Array[Array[Byte]]
+  gc_heap : Array[GcObject] // GC heap for struct/array instances
   mut error_detail : String
 }
 
@@ -31,6 +32,32 @@ fn RuntimeContext::new(
     tables,
     imported_funcs,
     data_segments,
+    gc_heap: [],
+    error_detail: "",
+  }
+}
+
+///|
+/// Create a new RuntimeContext with a pre-initialized gc_heap
+fn RuntimeContext::new_with_gc_heap(
+  module_ : @core.Module,
+  memory : Array[Byte],
+  memory_max : UInt64?,
+  globals : Array[Value],
+  tables : Array[RuntimeTable],
+  imported_funcs : Array[ImportedFunc],
+  data_segments : Array[Array[Byte]],
+  gc_heap : Array[GcObject],
+) -> RuntimeContext {
+  {
+    module_,
+    memory,
+    memory_max,
+    globals,
+    tables,
+    imported_funcs,
+    data_segments,
+    gc_heap,
     error_detail: "",
   }
 }

--- a/src/validate/validate_helpers.mbt
+++ b/src/validate/validate_helpers.mbt
@@ -343,6 +343,7 @@ fn table_index_type(table_type : @core.TableType) -> @core.ValType {
 /// - Reference instructions: ref.null, ref.func
 /// - @core.Global access: global.get
 /// - Arithmetic: i32.add, i32.sub, i32.mul, i64.add, i64.sub, i64.mul
+/// - GC instructions: struct.new, struct.new_default, array.new, array.new_default, etc.
 fn validate_const_expr_instructions(
   expr : @core.Expr,
 ) -> Unit raise ValidationError {
@@ -360,7 +361,14 @@ fn validate_const_expr_instructions(
       | I32Mul
       | I64Add
       | I64Sub
-      | I64Mul => () // Valid constant expression instructions
+      | I64Mul
+      // GC proposal constant expressions
+      | StructNew(_)
+      | StructNewDefault(_)
+      | ArrayNew(_)
+      | ArrayNewDefault(_)
+      | ArrayNewFixed(_, _)
+      | RefI31 => () // Valid constant expression instructions
       _ =>
         raise ValidationError::ConstantExpressionRequired(
           "invalid instruction in constant expression: \{instr}",
@@ -525,6 +533,177 @@ fn validate_storage_type(
 }
 
 ///|
+/// Check if type_idx1 is a declared subtype of type_idx2 via the type hierarchy
+/// This searches the supertype chain in type_groups and also checks structural subtyping
+fn is_type_index_subtype(
+  module_ : @core.Module,
+  type_idx1 : Int,
+  type_idx2 : Int,
+) -> Bool {
+  // Same type is always a subtype of itself
+  if type_idx1 == type_idx2 {
+    return true
+  }
+
+  // Search through type_groups to find explicit supertype declarations
+  for group in module_.type_groups {
+    for subtype_def in group.subtypes {
+      let current_idx = subtype_def.type_idx.reinterpret_as_int()
+      if current_idx == type_idx1 {
+        // Check if type_idx2 is a direct supertype
+        for supertype in subtype_def.supertypes {
+          let super_idx = supertype.reinterpret_as_int()
+          if super_idx == type_idx2 {
+            return true
+          }
+          // Recursively check if the supertype is a subtype of type_idx2
+          if is_type_index_subtype(module_, super_idx, type_idx2) {
+            return true
+          }
+        }
+      }
+    }
+  }
+
+  // Check structural subtyping for struct types
+  // A struct type S1 is a subtype of S2 if S2's fields are a prefix of S1's fields
+  // and corresponding field types are subtypes
+  if type_idx1 >= 0 &&
+    type_idx1 < module_.types.length() &&
+    type_idx2 >= 0 &&
+    type_idx2 < module_.types.length() {
+    match (module_.types[type_idx1], module_.types[type_idx2]) {
+      (Struct(struct1), Struct(struct2)) =>
+        // Check structural subtyping (S1 fields are superset of S2 fields)
+        if is_struct_subtype(module_, struct1, struct2) {
+          return true
+        }
+      (Array(arr1), Array(arr2)) =>
+        // Array types are subtypes if element types are subtypes
+        if is_array_subtype(module_, arr1, arr2) {
+          return true
+        }
+      (Func(func1), Func(func2)) =>
+        // Function types use contravariant parameters and covariant results
+        if is_func_type_subtype(module_, func1, func2) {
+          return true
+        }
+      _ => ()
+    }
+  }
+
+  false
+}
+
+///|
+/// Check if array1 is a subtype of array2
+fn is_array_subtype(
+  module_ : @core.Module,
+  arr1 : @core.ArrayType,
+  arr2 : @core.ArrayType,
+) -> Bool {
+  // Mutability must match
+  if arr1.element.mutable != arr2.element.mutable {
+    return false
+  }
+  is_storage_type_subtype(
+    module_,
+    arr1.element.storage,
+    arr2.element.storage,
+    arr1.element.mutable,
+  )
+}
+
+///|
+/// Check if func1 is a subtype of func2
+/// Parameters are contravariant, results are covariant
+fn is_func_type_subtype(
+  module_ : @core.Module,
+  func1 : @core.FuncType,
+  func2 : @core.FuncType,
+) -> Bool {
+  // Must have same number of params and results
+  if func1.params.length() != func2.params.length() ||
+    func1.results.length() != func2.results.length() {
+    return false
+  }
+
+  // Parameters are contravariant: func2.params[i] <: func1.params[i]
+  for i in 0..<func1.params.length() {
+    if not(is_subtype(module_, func2.params[i], func1.params[i])) {
+      return false
+    }
+  }
+
+  // Results are covariant: func1.results[i] <: func2.results[i]
+  for i in 0..<func1.results.length() {
+    if not(is_subtype(module_, func1.results[i], func2.results[i])) {
+      return false
+    }
+  }
+
+  true
+}
+
+///|
+/// Check if struct1 is a structural subtype of struct2
+/// struct1 <: struct2 if struct2's fields are a prefix of struct1's fields
+/// and each corresponding field type in struct1 is a subtype of struct2's field type
+fn is_struct_subtype(
+  module_ : @core.Module,
+  struct1 : @core.StructType,
+  struct2 : @core.StructType,
+) -> Bool {
+  // struct2 must have <= fields than struct1
+  if struct2.fields.length() > struct1.fields.length() {
+    return false
+  }
+
+  // Each field in struct2 must be compatible with corresponding field in struct1
+  for i in 0..<struct2.fields.length() {
+    let f1 = struct1.fields[i]
+    let f2 = struct2.fields[i]
+
+    // Mutability must match (or struct1 can be const when struct2 is mut for covariance)
+    // Actually in wasm-gc, field mutability must match exactly for subtyping
+    if f1.mutable != f2.mutable {
+      return false
+    }
+
+    // Field types must be subtypes (or equal for mutable fields)
+    if not(is_storage_type_subtype(module_, f1.storage, f2.storage, f1.mutable)) {
+      return false
+    }
+  }
+
+  true
+}
+
+///|
+/// Check if storage1 is a subtype of storage2
+/// For mutable fields, types must be equal (invariant)
+/// For immutable fields, types can be covariant
+fn is_storage_type_subtype(
+  module_ : @core.Module,
+  storage1 : @core.StorageType,
+  storage2 : @core.StorageType,
+  mutable : Bool,
+) -> Bool {
+  match (storage1, storage2) {
+    (Val(v1), Val(v2)) =>
+      if mutable {
+        // Mutable fields must have equal types
+        v1 == v2
+      } else {
+        // Immutable fields can be covariant
+        is_subtype(module_, v1, v2)
+      }
+    (I8, I8) | (I16, I16) => true
+    _ => false
+  }
+}
+
+///|
 /// Check if t1 is a subtype of t2 (t1 <: t2) with module context for type lookups
 /// WebAssembly GC type hierarchy:
 /// - NullRef (none) <: all nullable reference types
@@ -549,6 +728,9 @@ fn is_subtype(
     | (NullRef, I31Ref)
     | (NullRef, StructRef)
     | (NullRef, ArrayRef) => true
+    // NullRef is also a subtype of any nullable typed struct/array reference
+    (NullRef, Ref(TypeIndex(n), true)) =>
+      is_struct_type_index(module_, n) || is_array_type_index(module_, n)
     (NullFuncRef, FuncRef) => true
     // NullFuncRef is the bottom type for all function references,
     // so it's a subtype of any nullable typed function reference
@@ -567,8 +749,17 @@ fn is_subtype(
     (FuncRef, AnyRef) => true
     (ExnRef, AnyRef) => true
 
+    // TypeIndex subtyping: check declared supertype hierarchy FIRST
+    // (Must come before generic Ref pattern to match TypeIndex cases)
+    // Ref(TypeIndex(n1), nullable1) <: Ref(TypeIndex(n2), nullable2)
+    // if n1 is a declared subtype of n2 AND nullable1 <= nullable2
+    (Ref(TypeIndex(n1), nullable1), Ref(TypeIndex(n2), nullable2)) =>
+      // Non-nullable can be subtype of nullable, but not vice versa
+      // If target is nullable, any source is OK; if target is non-nullable, source must be non-nullable
+      (nullable2 || not(nullable1)) && is_type_index_subtype(module_, n1, n2)
     // Typed references: Ref(T, nullable)
     // Non-nullable is subtype of nullable for same heap type
+    // (For non-TypeIndex heap types like Func, Extern, etc.)
     (Ref(ht1, false), Ref(ht2, true)) => ht1 == ht2
     // Ref(Extern, _) is compatible with ExternRef (nullable externref)
     (Ref(Extern, _), ExternRef) => true

--- a/test/selfhost/test_wasm_gc.mjs
+++ b/test/selfhost/test_wasm_gc.mjs
@@ -1,0 +1,63 @@
+// Test wasm-gc build of wasm5
+import { readFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function main() {
+  console.log("=== wasm5 wasm-gc Build Test ===\n");
+
+  // Load wasm-gc version
+  const wasmPath = join(__dirname, '../../target/wasm-gc/release/build/cmd/wasm/wasm.wasm');
+  const wasmBytes = await readFile(wasmPath);
+  console.log(`Loaded wasm5 (wasm-gc): ${wasmBytes.length} bytes`);
+
+  // Load simple.wasm to test
+  const simpleWasmPath = join(__dirname, 'simple.wasm');
+  const simpleWasmBytes = await readFile(simpleWasmPath);
+  console.log(`Loaded simple.wasm: ${simpleWasmBytes.length} bytes`);
+
+  // Create memory and import object
+  const memory = new WebAssembly.Memory({ initial: 256, maximum: 1024 });
+  const importObject = {
+    env: { memory },
+    spectest: {
+      print_char: (c) => process.stdout.write(String.fromCharCode(c))
+    }
+  };
+
+  // Compile and instantiate
+  try {
+    const wasmModule = await WebAssembly.compile(wasmBytes);
+    console.log("\nwasm5 (wasm-gc) compiled successfully");
+
+    const wasmInstance = await WebAssembly.instantiate(wasmModule, importObject);
+    console.log("wasm5 (wasm-gc) instantiated successfully");
+
+    console.log("\nExports:", Object.keys(wasmInstance.exports));
+
+    // Check if parse_wasm exists (MoonBit-style interface)
+    if (wasmInstance.exports.parse_wasm) {
+      console.log("\nparse_wasm export found - wasm-gc uses MoonBit Bytes interface");
+    }
+
+    if (wasmInstance.exports._start) {
+      wasmInstance.exports._start();
+      console.log("_start() called successfully");
+    }
+
+  } catch (err) {
+    console.error("Error:", err.message);
+    process.exit(1);
+  }
+
+  console.log("\n" + "=".repeat(50));
+  console.log("wasm-gc build test completed");
+  console.log("=".repeat(50));
+}
+
+main().catch(err => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/test/selfhost/test_wasm_gc_cross.mjs
+++ b/test/selfhost/test_wasm_gc_cross.mjs
@@ -1,0 +1,119 @@
+// Cross-target test: wasm-gc interprets linear wasm
+// Tests that wasm5 (wasm-gc build) can interpret wasm5 (linear wasm build)
+import { readFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function stringToBytes(str) {
+  return new TextEncoder().encode(str);
+}
+
+async function main() {
+  console.log("=== Cross-Target Test: wasm-gc interprets linear wasm ===\n");
+
+  // Load wasm-gc version (outer interpreter)
+  const wasmGcPath = join(__dirname, '../../target/wasm-gc/release/build/cmd/wasm/wasm.wasm');
+  const wasmGcBytes = await readFile(wasmGcPath);
+  console.log(`Loaded wasm5 (wasm-gc): ${wasmGcBytes.length} bytes`);
+
+  // Load linear wasm version (to be interpreted)
+  const wasmPath = join(__dirname, '../../target/wasm/release/build/cmd/wasm/wasm.wasm');
+  const wasmBytes = await readFile(wasmPath);
+  console.log(`Loaded wasm5 (linear wasm): ${wasmBytes.length} bytes`);
+
+  // Create memory
+  const memory = new WebAssembly.Memory({ initial: 512, maximum: 1024 });
+  console.log(`Created memory: ${memory.buffer.byteLength / 1024 / 1024}MB`);
+
+  const importObject = {
+    env: { memory },
+    spectest: {
+      print_char: (c) => process.stdout.write(String.fromCharCode(c))
+    }
+  };
+
+  // Compile and instantiate wasm-gc (outer)
+  const wasmGcModule = await WebAssembly.compile(wasmGcBytes);
+  const wasmGcInstance = await WebAssembly.instantiate(wasmGcModule, importObject);
+  console.log("wasm5 (wasm-gc) outer instantiated\n");
+
+  const { _start, alloc, parse_wasm_raw, run_wasm_raw, call_i32_raw } = wasmGcInstance.exports;
+
+  _start();
+
+  // Copy linear wasm into memory
+  const wasmPtr = alloc(wasmBytes.length);
+  new Uint8Array(memory.buffer).set(wasmBytes, wasmPtr);
+  console.log(`Copied linear wasm to address ${wasmPtr}`);
+
+  // Test 1: wasm-gc parses linear wasm
+  console.log("\n" + "=".repeat(50));
+  console.log("TEST 1: wasm-gc parses linear wasm");
+  console.log("=".repeat(50));
+
+  let startTime = performance.now();
+  const parseResult = parse_wasm_raw(wasmPtr, wasmBytes.length);
+  let elapsed = performance.now() - startTime;
+
+  if (parseResult === 1) {
+    console.log(`✓ PASS: Parse successful (${elapsed.toFixed(2)}ms)`);
+  } else {
+    console.log("✗ FAIL: Parse failed");
+    process.exit(1);
+  }
+
+  // Test 2: wasm-gc loads and compiles linear wasm
+  console.log("\n" + "=".repeat(50));
+  console.log("TEST 2: wasm-gc loads & compiles linear wasm");
+  console.log("=".repeat(50));
+
+  const wasmPtr2 = alloc(wasmBytes.length);
+  new Uint8Array(memory.buffer).set(wasmBytes, wasmPtr2);
+
+  startTime = performance.now();
+  const runResult = run_wasm_raw(wasmPtr2, wasmBytes.length);
+  elapsed = performance.now() - startTime;
+
+  if (runResult === 1) {
+    console.log(`✓ PASS: Load & compile successful (${elapsed.toFixed(2)}ms)`);
+  } else {
+    console.log("✗ FAIL: Load & compile failed");
+    process.exit(1);
+  }
+
+  // Test 3: wasm-gc executes linear wasm's alloc()
+  console.log("\n" + "=".repeat(50));
+  console.log("TEST 3: wasm-gc executes linear wasm's alloc()");
+  console.log("=".repeat(50));
+
+  const wasmPtr3 = alloc(wasmBytes.length);
+  new Uint8Array(memory.buffer).set(wasmBytes, wasmPtr3);
+  const allocName = stringToBytes("alloc");
+  const namePtr = alloc(allocName.length);
+  new Uint8Array(memory.buffer).set(allocName, namePtr);
+
+  startTime = performance.now();
+  const allocResult = call_i32_raw(wasmPtr3, wasmBytes.length, namePtr, allocName.length, 100);
+  elapsed = performance.now() - startTime;
+
+  if (allocResult >= 2097152) {
+    console.log(`✓ PASS: alloc(100) = ${allocResult} (${elapsed.toFixed(2)}ms)`);
+  } else {
+    console.log(`✗ FAIL: alloc returned ${allocResult}`);
+    process.exit(1);
+  }
+
+  console.log("\n" + "=".repeat(50));
+  console.log("CROSS-TARGET TEST COMPLETE!");
+  console.log("=".repeat(50));
+  console.log("\nwasm5 (wasm-gc) successfully interpreted wasm5 (linear wasm):");
+  console.log(`  - wasm-gc size: ${wasmGcBytes.length} bytes`);
+  console.log(`  - linear wasm size: ${wasmBytes.length} bytes`);
+}
+
+main().catch(err => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/test/selfhost/test_wasm_gc_interpreter.mjs
+++ b/test/selfhost/test_wasm_gc_interpreter.mjs
@@ -1,0 +1,90 @@
+// wasm-gc interpreter execution test
+// Tests that wasm5 (wasm-gc build) can interpret and execute wasm modules
+import { readFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function stringToBytes(str) {
+  return new TextEncoder().encode(str);
+}
+
+async function main() {
+  console.log("=== wasm5 (wasm-gc) Interpreter Test ===\n");
+
+  // Load wasm-gc version
+  const wasmPath = join(__dirname, '../../target/wasm-gc/release/build/cmd/wasm/wasm.wasm');
+  const wasmBytes = await readFile(wasmPath);
+  console.log(`Loaded wasm5 (wasm-gc): ${wasmBytes.length} bytes`);
+
+  // Load add.wasm to test
+  const addWasmPath = join(__dirname, 'add.wasm');
+  const addWasmBytes = await readFile(addWasmPath);
+  console.log(`Loaded add.wasm: ${addWasmBytes.length} bytes`);
+
+  // Create memory and import object
+  const memory = new WebAssembly.Memory({ initial: 256, maximum: 1024 });
+  const importObject = {
+    env: { memory },
+    spectest: {
+      print_char: (c) => process.stdout.write(String.fromCharCode(c))
+    }
+  };
+
+  // Compile and instantiate
+  const wasmModule = await WebAssembly.compile(wasmBytes);
+  const wasmInstance = await WebAssembly.instantiate(wasmModule, importObject);
+  console.log("wasm5 (wasm-gc) instantiated\n");
+
+  const { _start, alloc, call_i32_i32_raw, call_i32_raw } = wasmInstance.exports;
+
+  _start();
+
+  // Allocate and copy add.wasm
+  const wasmPtr = alloc(addWasmBytes.length);
+  const wasmMemory = new Uint8Array(memory.buffer);
+  wasmMemory.set(addWasmBytes, wasmPtr);
+  console.log(`Copied add.wasm to address ${wasmPtr}`);
+
+  // Test 1: add(3, 4)
+  console.log("\n=== Test 1: add(3, 4) ===");
+  const addName = stringToBytes("add");
+  const namePtr = alloc(addName.length);
+  new Uint8Array(memory.buffer).set(addName, namePtr);
+
+  const result1 = call_i32_i32_raw(wasmPtr, addWasmBytes.length, namePtr, addName.length, 3, 4);
+  console.log(`Result: ${result1}`);
+  if (result1 === 7) {
+    console.log("✓ PASS: add(3, 4) = 7");
+  } else {
+    console.log(`✗ FAIL: expected 7, got ${result1}`);
+    process.exit(1);
+  }
+
+  // Test 2: double(21)
+  console.log("\n=== Test 2: double(21) ===");
+  const wasmPtr2 = alloc(addWasmBytes.length);
+  new Uint8Array(memory.buffer).set(addWasmBytes, wasmPtr2);
+  const doubleName = stringToBytes("double");
+  const namePtr2 = alloc(doubleName.length);
+  new Uint8Array(memory.buffer).set(doubleName, namePtr2);
+
+  const result2 = call_i32_raw(wasmPtr2, addWasmBytes.length, namePtr2, doubleName.length, 21);
+  console.log(`Result: ${result2}`);
+  if (result2 === 42) {
+    console.log("✓ PASS: double(21) = 42");
+  } else {
+    console.log(`✗ FAIL: expected 42, got ${result2}`);
+    process.exit(1);
+  }
+
+  console.log("\n" + "=".repeat(50));
+  console.log("wasm-gc INTERPRETER TEST PASSED!");
+  console.log("=".repeat(50));
+}
+
+main().catch(err => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/test/selfhost/test_wasm_gc_recursive.mjs
+++ b/test/selfhost/test_wasm_gc_recursive.mjs
@@ -1,0 +1,118 @@
+// wasm-gc recursive self-hosting test
+// Tests that wasm5 (wasm-gc) can parse, compile, and execute itself
+// Run with: node --stack-size=8192 test/selfhost/test_wasm_gc_recursive.mjs
+import { readFile } from 'fs/promises';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function stringToBytes(str) {
+  return new TextEncoder().encode(str);
+}
+
+async function main() {
+  console.log("=== wasm5 (wasm-gc) Recursive Self-Hosting Test ===\n");
+
+  // Load wasm-gc version
+  const wasmPath = join(__dirname, '../../target/wasm-gc/release/build/cmd/wasm/wasm.wasm');
+  const wasmBytes = await readFile(wasmPath);
+  console.log(`Loaded wasm5 (wasm-gc): ${wasmBytes.length} bytes`);
+
+  // Create memory (32MB for recursive self-hosting)
+  const memory = new WebAssembly.Memory({ initial: 512, maximum: 1024 });
+  console.log(`Created memory: ${memory.buffer.byteLength / 1024 / 1024}MB`);
+
+  const importObject = {
+    env: { memory },
+    spectest: {
+      print_char: (c) => process.stdout.write(String.fromCharCode(c))
+    }
+  };
+
+  // Compile and instantiate
+  const wasmModule = await WebAssembly.compile(wasmBytes);
+  const wasmInstance = await WebAssembly.instantiate(wasmModule, importObject);
+  console.log("wasm5 (wasm-gc) outer instantiated\n");
+
+  const { _start, alloc, parse_wasm_raw, run_wasm_raw, call_i32_raw } = wasmInstance.exports;
+
+  _start();
+
+  // Copy wasm5 into memory for the interpreter
+  const wasmPtr = alloc(wasmBytes.length);
+  const wasmMemory = new Uint8Array(memory.buffer);
+  wasmMemory.set(wasmBytes, wasmPtr);
+  console.log(`Copied wasm5 (wasm-gc) to address ${wasmPtr}`);
+  console.log(`Size: ${wasmBytes.length} bytes`);
+
+  // Test 1: Parse itself
+  console.log("\n" + "=".repeat(50));
+  console.log("TEST 1: Parse wasm5 (wasm-gc)");
+  console.log("=".repeat(50));
+
+  let startTime = performance.now();
+  const parseResult = parse_wasm_raw(wasmPtr, wasmBytes.length);
+  let elapsed = performance.now() - startTime;
+
+  if (parseResult === 1) {
+    console.log(`✓ PASS: Parse successful (${elapsed.toFixed(2)}ms)`);
+  } else {
+    console.log("✗ FAIL: Parse failed");
+    process.exit(1);
+  }
+
+  // Test 2: Load and compile itself
+  console.log("\n" + "=".repeat(50));
+  console.log("TEST 2: Load & compile wasm5 (wasm-gc)");
+  console.log("=".repeat(50));
+
+  const wasmPtr2 = alloc(wasmBytes.length);
+  new Uint8Array(memory.buffer).set(wasmBytes, wasmPtr2);
+
+  startTime = performance.now();
+  const runResult = run_wasm_raw(wasmPtr2, wasmBytes.length);
+  elapsed = performance.now() - startTime;
+
+  if (runResult === 1) {
+    console.log(`✓ PASS: Load & compile successful (${elapsed.toFixed(2)}ms)`);
+  } else {
+    console.log("✗ FAIL: Load & compile failed");
+    process.exit(1);
+  }
+
+  // Test 3: Execute alloc on inner wasm5
+  console.log("\n" + "=".repeat(50));
+  console.log("TEST 3: Execute inner wasm5's alloc()");
+  console.log("=".repeat(50));
+
+  const wasmPtr3 = alloc(wasmBytes.length);
+  new Uint8Array(memory.buffer).set(wasmBytes, wasmPtr3);
+  const allocName = stringToBytes("alloc");
+  const namePtr = alloc(allocName.length);
+  new Uint8Array(memory.buffer).set(allocName, namePtr);
+
+  startTime = performance.now();
+  const allocResult = call_i32_raw(wasmPtr3, wasmBytes.length, namePtr, allocName.length, 100);
+  elapsed = performance.now() - startTime;
+
+  if (allocResult >= 2097152) {
+    console.log(`✓ PASS: alloc(100) = ${allocResult} (${elapsed.toFixed(2)}ms)`);
+  } else {
+    console.log(`✗ FAIL: alloc returned ${allocResult}`);
+    process.exit(1);
+  }
+
+  console.log("\n" + "=".repeat(50));
+  console.log("wasm-gc RECURSIVE SELF-HOSTING COMPLETE!");
+  console.log("=".repeat(50));
+  console.log("\nwasm5 (wasm-gc) successfully:");
+  console.log("  1. Parsed its own wasm-gc binary");
+  console.log("  2. Compiled its own bytecode interpreter");
+  console.log("  3. Executed its own alloc() function");
+}
+
+main().catch(err => {
+  console.error("Error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
I tried recursive bootstrapping, where wasm5.wasm can run wasm5.wasm with the wasm-gc target.
moonbitlang/async doesn't support --target wasm yet, but I've confirmed that everything else works.

- Implement ref.test/ref.cast with runtime type checking
- Fix br_on_cast/br_on_cast_fail with proper type compatibility
- Implement array.new_elem, array.init_data, array.init_elem
- Add runtime type checking helpers (gc_ref_matches_type, gc_is_type_subtype)
- Update compile_emit.mbt to emit new GC operations
- Add selfhost documentation and test scripts