### PR TITLE
Simplify runtime API: remove unnecessary Runtime returns

### DIFF
--- a/cmd/main/main.mbt
+++ b/cmd/main/main.mbt
@@ -12,8 +12,8 @@ async fn run_wasm(wasm_path : String) -> Unit {
   let wasm_bytes = @fs.read_file(wasm_path).binary()
   let module_ = @wasm5_parse.parse(wasm_bytes)
   let runtime = @wasm5_runtime.Runtime::load(module_)
-  let runtime = runtime.run_start()
-  let (_, results) = runtime.call_compiled("_start", [])
+  runtime.run_start()
+  let results = runtime.call_compiled(b"_start", [])
   if results.length() > 0 {
     println("Result: \{results}")
   }

--- a/src/runtime/compile_emit_wbtest.mbt
+++ b/src/runtime/compile_emit_wbtest.mbt
@@ -267,6 +267,6 @@ test "compile emit covers instructions" {
   let instrs = build_compile_instrs()
   let module_ = make_compile_module(instrs)
   let runtime = Runtime::load(module_)
-  let runtime = runtime.run_start()
+  runtime.run_start()
   assert_eq(runtime.ops.length() > 0, true)
 }

--- a/src/runtime/compile_runtime.mbt
+++ b/src/runtime/compile_runtime.mbt
@@ -1,7 +1,6 @@
 ///|
 /// Run the start function if present.
-/// Returns the runtime after start function execution (if any).
-pub fn Runtime::run_start(self : Runtime) -> Runtime raise RuntimeError {
+pub fn Runtime::run_start(self : Runtime) -> Unit raise RuntimeError {
   // Execute the start function if present
   match self.ctx.module_.start {
     Some(start_idx) => {
@@ -31,16 +30,11 @@ pub fn Runtime::run_start(self : Runtime) -> Runtime raise RuntimeError {
 
         // Execute start function, ignoring runtime errors
         // (e.g., calls to unimplemented imported functions)
-        let rt = execute(rt) catch {
-          _ => rt // Ignore runtime errors in start function
-        }
+        let _ = execute(rt) catch { _ => rt }
 
-        // Return with cleared stack
-        return { ..rt, sp: 0 }
       }
-      self
     }
-    None => self
+    None => ()
   }
 }
 
@@ -86,12 +80,11 @@ fn execute_call(
 
 ///|
 /// Call a compiled function by name with the given arguments.
-/// Returns tuple of (updated Runtime, results).
 pub fn Runtime::call_compiled(
   self : Runtime,
   func_name : Bytes,
   args : Array[Value],
-) -> (Runtime, Array[Value]) raise RuntimeError {
+) -> Array[Value] raise RuntimeError {
   let mut func_idx : Int? = None
   for exp in self.ctx.module_.exports {
     if exp.name == func_name {
@@ -112,7 +105,7 @@ pub fn Runtime::call_compiled(
   // Check if it's an imported function - call it directly via import resolver
   if idx < num_imported_funcs {
     let imported_func = self.ctx.imported_funcs[idx]
-    return (self, (imported_func.func)(args))
+    return (imported_func.func)(args)
   }
 
   // Adjust to local function index
@@ -146,7 +139,7 @@ pub fn Runtime::call_compiled(
       results.push(stack_to_value(rt.stack.unsafe_get(i), result_types[i]))
     }
   }
-  (rt, results)
+  results
 }
 
 ///|
@@ -156,7 +149,7 @@ pub fn Runtime::call_by_index(
   self : Runtime,
   func_idx : Int,
   args : Array[Value],
-) -> (Runtime, Array[Value]) raise RuntimeError {
+) -> Array[Value] raise RuntimeError {
   let num_imported_funcs = count_imported_funcs(self.ctx.module_)
 
   // Check if it's an imported function - call it directly via import resolver
@@ -167,7 +160,7 @@ pub fn Runtime::call_by_index(
       )
     }
     let imported_func = self.ctx.imported_funcs[func_idx]
-    return (self, (imported_func.func)(args))
+    return (imported_func.func)(args)
   }
 
   // Adjust to local function index
@@ -205,5 +198,5 @@ pub fn Runtime::call_by_index(
       results.push(stack_to_value(rt.stack.unsafe_get(i), result_types[i]))
     }
   }
-  (rt, results)
+  results
 }

--- a/src/runtime/pkg.generated.mbti
+++ b/src/runtime/pkg.generated.mbti
@@ -78,14 +78,14 @@ pub struct Runtime {
   status : RuntimeStatus
   ctx : RuntimeContext
 }
-pub fn Runtime::call_by_index(Self, Int, Array[Value]) -> (Self, Array[Value]) raise RuntimeError
-pub fn Runtime::call_compiled(Self, Bytes, Array[Value]) -> (Self, Array[Value]) raise RuntimeError
+pub fn Runtime::call_by_index(Self, Int, Array[Value]) -> Array[Value] raise RuntimeError
+pub fn Runtime::call_compiled(Self, Bytes, Array[Value]) -> Array[Value] raise RuntimeError
 pub fn Runtime::get_globals(Self) -> Array[Value]
 pub fn Runtime::get_module(Self) -> @core.Module
 pub fn Runtime::get_tables(Self) -> Array[RuntimeTable]
 pub fn Runtime::load(@core.Module) -> Self raise RuntimeError
 pub fn Runtime::load_with_resolver(@core.Module, ImportResolver) -> Self raise RuntimeError
-pub fn Runtime::run_start(Self) -> Self raise RuntimeError
+pub fn Runtime::run_start(Self) -> Unit raise RuntimeError
 
 pub struct RuntimeContext {
   module_ : @core.Module

--- a/src/runtime/runtime_exec_wbtest.mbt
+++ b/src/runtime/runtime_exec_wbtest.mbt
@@ -36,7 +36,7 @@ test "runtime compile start function" {
   }
   let module_ = module_with([func_type], [0U], [code], [], [], Some(0U))
   let rt = Runtime::load_with_resolver(module_, ImportResolver::new())
-  let rt = rt.run_start()
+  rt.run_start()
   assert_eq(rt.ops.length() > 0, true)
   // Stack is cleared after start function execution (unified stack model)
   assert_eq(rt.sp, 0)
@@ -80,7 +80,7 @@ test "runtime call compiled imported func" {
     ImportedFunc::new(0U, fn(_args) { [Value::I32(7U)] }),
   )
   let rt = Runtime::load_with_resolver(module_, resolver)
-  let (_, results) = rt.call_compiled(b"f", [])
+  let results = rt.call_compiled(b"f", [])
   assert_eq(results, [Value::I32(7U)])
 }
 
@@ -112,7 +112,7 @@ test "runtime call compiled non func export" {
   let _ = rt.call_compiled(b"mem", []) catch {
     _ => {
       saw_error = true
-      (rt, [])
+      []
     }
   }
   assert_eq(saw_error, true)
@@ -142,7 +142,7 @@ test "runtime call compiled local errors" {
   let _ = rt_bad.call_compiled(b"bad", []) catch {
     _ => {
       saw_bad = true
-      (rt_bad, [])
+      []
     }
   }
   assert_eq(saw_bad, true)

--- a/src/runtime/runtime_imported_file_test.mbt
+++ b/src/runtime/runtime_imported_file_test.mbt
@@ -21,8 +21,8 @@ async test "runtime parse imported wasm file with host side effects" {
   )
   resolver.add_global(b"host", b"g", Value::I32(42U))
   let rt = Runtime::load_with_resolver(module_, resolver)
-  let rt = rt.run_start()
-  let (_, results) = rt.call_compiled(b"run", [])
+  rt.run_start()
+  let results = rt.call_compiled(b"run", [])
   assert_eq(results.length(), 0)
   assert_eq(calls, [42U])
 }

--- a/src/runtime/runtime_test.mbt
+++ b/src/runtime/runtime_test.mbt
@@ -58,8 +58,8 @@ fn make_import_call_module() -> @core.Module {
 test "runtime call compiled constant" {
   let module_ = make_const_module(42U, b"answer")
   let runtime = Runtime::load(module_)
-  let runtime = runtime.run_start()
-  let (_, results) = runtime.call_compiled(b"answer", [])
+  runtime.run_start()
+  let results = runtime.call_compiled(b"answer", [])
   assert_eq(results.length(), 1)
   assert_eq(results[0], Value::I32(42U))
 }
@@ -71,8 +71,8 @@ test "runtime call imported function" {
   let imported = ImportedFunc::new(0U, fn(_args) { [Value::I32(7U)] })
   resolver.add_func(b"m", b"f", imported)
   let runtime = Runtime::load_with_resolver(module_, resolver)
-  let runtime = runtime.run_start()
-  let (_, results) = runtime.call_compiled(b"call_imported", [])
+  runtime.run_start()
+  let results = runtime.call_compiled(b"call_imported", [])
   assert_eq(results.length(), 1)
   assert_eq(results[0], Value::I32(7U))
 }

--- a/test/harness.mbt
+++ b/test/harness.mbt
@@ -75,7 +75,7 @@ async fn parse_and_compile(
   let content = file.read_all().binary()
   let module_ = @wasm5_parse.parse(content)
   let runtime = @wasm5_runtime.Runtime::load_with_resolver(module_, resolver)
-  let runtime = runtime.run_start()
+  runtime.run_start()
   runtime
 }
 
@@ -92,13 +92,9 @@ fn make_import_wrapper(
   ) {
     // Call the registered module's exported function
     let rt = registered.runtime
-    let (_, results) = rt.call_compiled(
-      @encoding/utf8.encode(export_name),
-      args,
-    ) catch {
-      _ => (rt, [])
+    rt.call_compiled(@encoding/utf8.encode(export_name), args) catch {
+      _ => []
     }
-    results
   }
   @wasm5_runtime.ImportedFunc::new(arity, func)
 }
@@ -116,8 +112,9 @@ fn make_funcref_wrapper(
   ) {
     // Call the registered module's function by index
     let rt = registered.runtime
-    let (_, results) = rt.call_by_index(func_idx, args) catch { _ => (rt, []) }
-    results
+    rt.call_by_index(func_idx, args) catch {
+      _ => []
+    }
   }
   @wasm5_runtime.ImportedFunc::new(arity, func)
 }
@@ -877,10 +874,7 @@ fn handle_assert_return(
       ctx.fail(line, "assert_return", msg)
       return
     }
-    let (_, results) = rt.call_compiled(
-      @encoding/utf8.encode(fn_name),
-      runtime_args,
-    )
+    let results = rt.call_compiled(@encoding/utf8.encode(fn_name), runtime_args)
     // Check result count
     if expected.length() != results.length() {
       ctx.fail(


### PR DESCRIPTION
- run_start() now returns Unit instead of Runtime
- call_compiled() now returns Array[Value] instead of (Runtime, Array[Value])
- call_by_index() now returns Array[Value] instead of (Runtime, Array[Value])

The returned Runtime was never used - callers always ignored it with `let _ =` or `let (_, results) =`. This makes the API cleaner and consistent with CRuntime.